### PR TITLE
Changing field ordering in Model

### DIFF
--- a/docs/source/Model.rst
+++ b/docs/source/Model.rst
@@ -1,0 +1,8 @@
+======================================
+Model
+======================================
+
+.. automodule:: WallSpeed.model
+    :members:
+    :inherited-members:
+    :special-members: __init__

--- a/docs/source/Thermodynamics.rst
+++ b/docs/source/Thermodynamics.rst
@@ -1,0 +1,8 @@
+======================================
+Thermodynamics
+======================================
+
+.. automodule:: WallSpeed.Thermodynamics
+    :members:
+    :inherited-members:
+    :special-members: __init__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,8 @@ If you use WallSpeed, please cite arXiv:....
     Grid
     Hydro
     Polynomial
+    Model
+    Thermodynamics
 
 .. toctree::
     :caption: Getting Started:

--- a/src/WallSpeed/EOM.py
+++ b/src/WallSpeed/EOM.py
@@ -144,7 +144,7 @@ class EOM:
         wallOffsets = wallParams[self.nbrFields:]
         X,dXdz = self.wallProfile(self.grid.xiValues, vevLowT, vevHighT, wallWidths, wallOffsets)
         # TODO: Change X.T to X when freeEnergy gets the right ordering.
-        dVdX = self.freeEnergy.derivField(X.T, Tprofile).T
+        dVdX = self.freeEnergy.derivField(X, Tprofile)
         pressure = -GCLQuadrature(np.concatenate(([0], self.grid.L_xi*(dVdX*dXdz)[0]/(1-self.grid.chiValues**2), [0])))
         
         if returnOptimalWallParams:

--- a/src/WallSpeed/model.py
+++ b/src/WallSpeed/model.py
@@ -175,13 +175,13 @@ class Model:
         }
 
 
-    def V0(self,X,show_V=False):
+    def V0(self, X, show_V=False):
         '''
         Tree level effective potential
         X
         '''
         X = np.asanyarray(X)
-        h1,s1 = X[...,0],X[...,1]
+        h1,s1 = X[0,...],X[1,...]
         V = (
            +1/2*self.muhsq*h1**2
            +1/2*self.mussq*s1**2
@@ -200,7 +200,7 @@ class Model:
 
     def boson_massSq(self, X, T):
         X = np.asanyarray(X)
-        h1,s1 = X[...,0],X[...,1]
+        h1,s1 = X[0,...],X[1,...]
 
         Nbosons = 5
         dof = np.array([1,1,3,6,3])#h,s,chi,W,Z
@@ -225,7 +225,7 @@ class Model:
 
     def fermion_massSq(self, X):
         X = np.asanyarray(X)
-        h1,s1 = X[...,0],X[...,1]
+        h1,s1 = X[0,...],X[1,...]
 
         Nfermions = 1
         dof = np.array([12])
@@ -267,7 +267,7 @@ class Model:
         (this allows for negative mass-squared values, which I take to be the
         real part of the defining integrals.
 
-        .. todo::
+        todo:
             Implement new versions of Jf and Jb that return zero when m=0, only
             adding in the field-independent piece later if
             ``include_radiation == True``. This should reduce floating point
@@ -365,6 +365,8 @@ class FreeEnergy:
         cls : FreeEnergy
             An object of the FreeEnergy class.
         """
+        self.nbrFields = 2
+
         if params is None:
             self.f = f
             self.dfdT = dfdT
@@ -483,18 +485,18 @@ class FreeEnergy:
         else:
             X = np.asanyarray(X, dtype=float)
             # TODO generalise to arbitrary fields
-            h, s = X[..., 0], X[..., 1]
+            h, s = X[0,...], X[1,...]
             Xdh = X.copy()
-            Xdh[..., 0] += self.dPhi * np.ones_like(h)
+            Xdh[0,...] += self.dPhi * np.ones_like(h)
             Xds = X.copy()
-            Xds[..., 1] += self.dPhi * np.ones_like(h)
+            Xds[1,...] += self.dPhi * np.ones_like(h)
 
             dfdh = (self(Xdh, T) - self(X, T)) / self.dPhi
             dfds = (self(Xds, T) - self(X, T)) / self.dPhi
 
             return_val = np.empty_like(X)
-            return_val[..., 0] = dfdh
-            return_val[..., 1] = dfds
+            return_val[0,...] = dfdh
+            return_val[1,...] = dfds
 
             return return_val
 

--- a/tests/test_veff.py
+++ b/tests/test_veff.py
@@ -14,7 +14,7 @@ def test_BM1():
     Tminus = 100.1
     mod = WallSpeed.Model(125, 120, 1.0, 0.9)
     params = mod.params
-    res = mod.Vtot([[110, 130]], 100)
+    res = mod.Vtot([[110],[130]], 100)
     assert res == pytest.approx(-1.19018205e09, rel=1e-2)
     free = WallSpeed.FreeEnergy(mod.Vtot, Tc, Tnucl=Tn, params=params)
     res = free.findPhases(100)
@@ -35,17 +35,17 @@ def test_BM1():
 
 def test_BM2():
     mod = WallSpeed.Model(125, 160.0, 1.0, 1.2)
-    res = mod.Vtot([[110, 130]], 100)
+    res = mod.Vtot([[110],[130]], 100)
     assert res == pytest.approx(-1.15450678e09, rel=1e-2)
 
 
 def test_BM3():
     mod = WallSpeed.Model(125, 160, 1.0, 1.6)
-    res = mod.Vtot([[110, 130]], 100)
+    res = mod.Vtot([[110],[130]], 100)
     assert res == pytest.approx(-1.23684861e09, rel=1e-2)
 
 
 def test_BM4():
     mod = WallSpeed.Model(125, 80, 1.0, 0.5)
-    res = mod.Vtot([[100, 100]], 100)
+    res = mod.Vtot([[100],[100]], 100)
     assert res == pytest.approx(-1210419844, rel=1e-2)


### PR DESCRIPTION
change field ordering in model.py
number of fields in FreeEnergy: FreeEnergy.nbrFields
fix X.T -> X request in EOM
docs for Model and Thermodynamics