### PR TITLE
Fixed -n option in collision

### DIFF
--- a/Collision/src/main.cpp
+++ b/Collision/src/main.cpp
@@ -160,7 +160,8 @@ int main(int argc, char *argv[]) {
 				printUsage(stderr, argv[0]);
 				return 0;
 			case 'n':
-				basisSizeN = int(*optarg) - int('0');
+				// NB: atoi is not the best option as it will happily interpret eg. "20dog" as 20
+				basisSizeN = std::atoi(optarg);
 				std::cout << "Running with basis size "<< basisSizeN << "\n";
 				break;
 			case 'w':
@@ -174,8 +175,13 @@ int main(int argc, char *argv[]) {
 						fprintf(stderr, "Unknown option character `\\x%x'.\n", opt);
 				return 1;
 			default:
-				abort();
+				return 1;
 		}
+	}
+
+	if (basisSizeN < 1) {
+		std::cerr << "Invalid basis size N = " << basisSizeN << "\n";
+		return 2;
 	}
 
 	// Load config
@@ -186,7 +192,7 @@ int main(int argc, char *argv[]) {
 		config.printContents();
 		std::cout << std::endl;
 	} else {
-		return 1;
+		return 3;
 	}
 
 


### PR DESCRIPTION
Fixed bug with the -n option that sets basis size.  The previous version did not work for N >= 10. 