### PR TITLE
tell github workflow to use apple clang compiler on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
                sudo apt-get install libgsl-dev libhdf5-dev
              elif [ "$RUNNER_OS" == "macOS" ]; then
                brew update
-               brew install cpp-gsl, hdf5
+               brew install gsl hdf5
              else
                echo "$RUNNER_OS not supported"
                exit 1


### PR DESCRIPTION
Fixed workflow to properly build on macOS, previously it ran ubuntu-latest for everything. The workflow file should also be cleaner now.

The C++ compiler used by macOS build is AppleClang 14.0.0.14000029 so that is working too. However for some reason the macOS build does not find OpenMP installation but I don't consider this crucial right now.