### PR TITLE
The right index should act on a Chebyshev-bases array

### DIFF
--- a/src/WallSpeed/Boltzmann.py
+++ b/src/WallSpeed/Boltzmann.py
@@ -105,7 +105,7 @@ class BoltzmannSolver:
             deltaF = self.solveBoltzmannEquations()
             # putting deltaF on momentum coordinate grid points
             deltaFCoord = np.einsum(
-                "abc, ai, bj, ck -> ijk",
+                "abc, ia, jb, kc -> ijk",
                 deltaF,
                 self.poly.matrix(self.basisM, "z"),
                 self.poly.matrix(self.basisN, "pz"),


### PR DESCRIPTION
To make the bases transformation correctly the right index of the transformation matrix, M_{ij}=C_j(x_i), should act on a Chebyshev-bases array. This has now been implemented to the code.