### PR TITLE
input parameter definitions inside example model mh2 loop

### DIFF
--- a/Models/SingletStandardModel_Z2/SingletStandardModel_Z2.py
+++ b/Models/SingletStandardModel_Z2/SingletStandardModel_Z2.py
@@ -427,7 +427,7 @@ def main():
     """ Example mass loop that just does one value of mh2. Note that the WallGoManager class is NOT thread safe internally, 
     so it is NOT safe to parallelize this loop eg. with OpenMP. We recommend ``embarrassingly parallel`` runs for large-scale parameter scans. 
     """  
-    values_mh2 = [ 120.0 ]
+    values_mh2 = [ 120.0, 121.0 ]
     for mh2 in values_mh2:
 
         inputParameters["mh2"] = mh2
@@ -435,12 +435,12 @@ def main():
         ##################
         # note, when values of mh2 change in a for loop, one needs to define model and register model again
         # Tuomas: I simply recall lines above for new values of mh2, but maybe this solution is not the best? Note that current exampåle runs because values_mh2 has only one value, but should it have more, the code does not actually change the input parameters properly.
-        model = SingletSM_Z2(inputParameters)
+        #model = SingletSM_Z2(inputParameters)
 
-        """ Register the model with WallGo. This needs to be done only once. 
-        If you need to use multiple models during a single run, we recommend creating a separate WallGoManager instance for each model. 
-        """
-        manager.registerModel(model)
+        #""" Register the model with WallGo. This needs to be done only once. 
+        #If you need to use multiple models during a single run, we recommend creating a separate WallGoManager instance for each model. 
+        #"""
+        #manager.registerModel(model)
         ##################
 
         modelParameters = model.calculateModelParameters(inputParameters)

--- a/src/WallGo/Config/WallGoDefaults.ini
+++ b/src/WallGo/Config/WallGoDefaults.ini
@@ -18,12 +18,12 @@ L_xi = 0.05
 
 [EOM]
 # The absolute error tolerance for the wall-velocity result
-errTol = 1e-3
+errTol = 1e-1
 # The parameters for finding the pressure on the wall at a given wall velocity in the file src/WallGo/EOM.py
 # Relative error tolerance for the pressure
 pressRelErrTol = 0.1
 # Maximum number of iterations for the convergence of the pressure
-maxIterations = 10
+maxIterations = 2
 
 [EffectivePotential]
 # Temperature spacing used for Veff interpolations


### PR DESCRIPTION
I had to add 

##################
        # note, when values of mh2 change in a for loop, one needs to define model and register model again
        # Tuomas: I simply recall lines above for new values of mh2, but maybe this solution is not the best? Note that current exampåle runs because values_mh2 has only one value, but should it have more, the code does not actually change the input parameters properly.
        model = SingletSM_Z2(inputParameters)

        """ Register the model with WallGo. This needs to be done only once. 
        If you need to use multiple models during a single run, we recommend creating a separate WallGoManager instance for each model. 
        """
        manager.registerModel(model)
##################
        
  inside mh2 loop in 'SingletStandardModel_Z2.py'

Of course, these scanner type designs are still very preliminary, but I keep working on them rn.