### PR TITLE
Linting, type-checking and formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,4 @@ variable-naming-style = "camelCase"
 warn_return_any = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
+disable_error_code = "import-untyped"


### PR DESCRIPTION
This is a pull request to set the linting, type-checking and formatting rules for the project. The necessary libraries can be installed with the following in the base directory:
```
python3 -m pip install -e ".[lint]"
```

**Type-checking:**

- done with `mypy`
- requires defs to have all types defined
- can run on command line with e.g. `mypy src/WallGo/GenericModel.py` to check a file.
- can also get to run automatically in your text editor, e.g. on VSCode install the `Mypy type checker` extension

**Linting:**

- done with `pylint`
- fixes line length at 88
- in part follows [PEP8](https://pep8.org/), the Python standard
- however, PEP8 requires snake_case where we have used camelCase, so I have overwritten this in the config
- can be run on command line with e.g. `pylint src/WallGo/GenericModel.py` to check a file.
- can also get to run automatically in your text editor, e.g. on VSCode install the `Pylint` extension

**Formatting:**

- done with Python `black`
- this basically just does some of the linting automatically, and should conform with the `pylint` rules above.
- can be run on command line with e.g. `black src/WallGo/GenericModel.py` to format a file.
- can also get to run automatically in your text editor, e.g. on VSCode install the `Black Formatter` extension