### PR TITLE
Remove row_stack which is to be deprecated

### DIFF
--- a/src/WallGo/Fields.py
+++ b/src/WallGo/Fields.py
@@ -53,7 +53,7 @@ class Fields(np.ndarray):
 
     # Custom constructor that stacks 1D arrays or lists of field-space points into a 2D array 
     def __new__(cls, *fieldSpacePoints: Tuple[FieldPoint]):
-        obj = np.row_stack(fieldSpacePoints)
+        obj = np.vstack(fieldSpacePoints)
         obj = np.atleast_2d(obj)
         return obj.view(cls)
     


### PR DESCRIPTION
Updated local packages and found lots of warnings locally (like on GitHub). This was all fixed locally by a single change to the source code `row_stack` to `vstack`. Let's see if it fixed them on the repo too.