### PR TITLE
Revert collision metadata field name back to lower-case 'metadata'

### DIFF
--- a/Collision/src/hdf5Interface.cpp
+++ b/Collision/src/hdf5Interface.cpp
@@ -17,7 +17,7 @@ void writeMetadata(H5::H5File& h5File, const CollisionMetadata& metadata)
 	try
 	{
 		// Create a group to hold metadata (keeping it separate from the actual data)
-		H5::Group metadataGroup = h5File.createGroup("Metadata");
+		H5::Group metadataGroup = h5File.createGroup("metadata");
 
 		// Create attributes in the group. One attribute for each variable in metadata struct
 		H5::Attribute basisSizeAttr = metadataGroup.createAttribute("Basis Size", H5::PredType::NATIVE_INT, H5::DataSpace());


### PR DESCRIPTION
Undoes a strike of genius I had in earlier PR which sneakily changed "metadata" to "Metadata". But this breaks HDF5 loading of new files in collisionArray.py, so not good.

Will merge in the morning when I wake up zZz