### PR TITLE
Additional test of the Jouguet velocity

### DIFF
--- a/src/WallGo/hydrodynamics.py
+++ b/src/WallGo/hydrodynamics.py
@@ -157,11 +157,23 @@ class Hydrodynamics:
 
         if rootResult.converged:
             tmSol = rootResult.root
+
         else:
             raise WallGoError(
                 "Failed to solve Jouguet velocity at \
                               input temperature!",
                 data={"flag": rootResult.flag, "Root result": rootResult},
+            )
+        
+        # Denominator of the derivative of vp^2 
+        vpDerivDenom = (self.thermodynamics.eLowT(tmSol) - eHighT)**2*(eHighT + self.thermodynamics.pLowT(tmSol))**2
+
+        # Additional check if solution meets some tolerance requirement
+        # HACK value 1e-3 is a bit arbitrary. Figure out more robust estimate.
+        if np.abs(vpDerivNum(tmSol)/vpDerivDenom)*tmSol > 1e-3:
+            raise WallGoError(
+                "Failed to solve Jouguet velocity at sufficient precision!",
+                data={"rtol": self.rtol, "vpDerivNum/vpDerivDenom": vpDerivNum(tmSol)/vpDerivDenom},
             )
 
         vp = np.sqrt(


### PR DESCRIPTION
Very small pull request:

While testing the dependence on temperatureScale for SM light Higgs, I noticed that the Jouguet velocity was not always correctly identified. 
I implemented an additional test, such that it uses the template model Jouguet velocity in this case. The criterion is a bit arbitrary, so I would like to come back to this later, to put a better motivated number in the comparison. (I tried with the rtol first, but that was so strict that our tests started to fail)