### PR TITLE
Energy conservation flag

### DIFF
--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -341,9 +341,20 @@ class YukawaModelExample(WallGoExampleBase):
         momentum is not enforced to increase stability.
         """
         super().configureManager(inOutManager)
+        
+        # Increase the number of grid points to increase stability
         inOutManager.config.set("PolynomialGrid", "spatialGridSize", "50")
+        
+        # In the Yukawa model, most degrees of freedom are treated as out-of-equilibrium
+        # This creates an approximate degeneracy in the definition of f_{eq} vs \delta f
+        # If we enforce conservation of EM, this will lead to a divergence of the
+        # iteration procedure. So we don't enforce it.
         inOutManager.config.set("EquationOfMotion", "conserveEnergyMomentum", "0")
+        
+        # The potential is polynomial, so it has a smaller error
         inOutManager.config.set("EffectivePotential", "potentialError", "1e-14")
+        
+        # Decrease the phase tracer tolerance to improve stability
         inOutManager.config.set("EffectivePotential", "phaseTracerTol", "1e-8")
 
     def updateModelParameters(
@@ -388,6 +399,8 @@ class YukawaModelExample(WallGoExampleBase):
                 WallGo.WallSolverSettings(
                     # we actually do both cases in the common example
                     bIncludeOffEquilibrium=True,
+                    # meanFreePathScale is determined here by the annihilation channels,
+                    # which go like y^4~1e-3. This is why it has to be small.
                     meanFreePathScale=1000000.0, # In units of 1/Tnucl
                     wallThicknessGuess=50.0, # In units of 1/Tnucl
                 ),

--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -336,9 +336,15 @@ class YukawaModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """Yukawa example uses spatial grid size = 20"""
+        """
+        Yukawa example uses spatial grid size = 50 and conservation of energy and
+        momentum is not enforced to increase stability.
+        """
         super().configureManager(inOutManager)
-        inOutManager.config.set("PolynomialGrid", "spatialGridSize", "20")
+        inOutManager.config.set("PolynomialGrid", "spatialGridSize", "50")
+        inOutManager.config.set("EquationOfMotion", "conserveEnergyMomentum", "0")
+        inOutManager.config.set("EffectivePotential", "potentialError", "1e-14")
+        inOutManager.config.set("EffectivePotential", "phaseTracerTol", "1e-8")
 
     def updateModelParameters(
         self, model: "YukawaModel", inputParameters: dict[str, float]
@@ -382,8 +388,8 @@ class YukawaModelExample(WallGoExampleBase):
                 WallGo.WallSolverSettings(
                     # we actually do both cases in the common example
                     bIncludeOffEquilibrium=True,
-                    meanFreePathScale=100.0, # In units of 1/Tnucl
-                    wallThicknessGuess=5.0, # In units of 1/Tnucl
+                    meanFreePathScale=1000000.0, # In units of 1/Tnucl
+                    wallThicknessGuess=80.0, # In units of 1/Tnucl
                 ),
             )
         )

--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -389,7 +389,7 @@ class YukawaModelExample(WallGoExampleBase):
                     # we actually do both cases in the common example
                     bIncludeOffEquilibrium=True,
                     meanFreePathScale=1000000.0, # In units of 1/Tnucl
-                    wallThicknessGuess=80.0, # In units of 1/Tnucl
+                    wallThicknessGuess=50.0, # In units of 1/Tnucl
                 ),
             )
         )

--- a/Models/wallGoExampleBase.py
+++ b/Models/wallGoExampleBase.py
@@ -387,6 +387,7 @@ class WallGoExampleBase(ABC):
                         the example.
                         """
                     )
+                raise e
 
             if self.cmdArgs.includeDetonations:
                 print("\n=== Search for detonation solution ===")

--- a/src/WallGo/Config/WallGoDefaults.ini
+++ b/src/WallGo/Config/WallGoDefaults.ini
@@ -33,6 +33,10 @@ maxIterations = 20
 
 # Flag to enforce conservation of energy and momentum. 
 # If 1, it is enforced. If 0, it is not.
+# Normally, this should be set to 1, but it can help with numerical stability
+# to set it to 0. If 1, there is an ambiguity in the separation between
+# f_{eq} and \delta f when the out-of-equilibrium particles form a closed 
+# system (or nearly closed). This can lead to a divergence of the iterative loop.
 conserveEnergyMomentum = 1
 
 # Bounds on wall thickness (in units of 1/Tnucl)
@@ -89,4 +93,5 @@ tmin = 0.8
 # Can be used for testing or for studying the solution's sensibility
 # to the collision integrals. Don't forget to adjust meanFreePath
 # accordingly if this is different from 1 (meanFreePath ~ 1/collisionMultiplier).
+# WARNING: THIS CHANGES THE COLLISION TERMS WRT TO THEIR PHYSICAL VALUE
 collisionMultiplier = 1.0

--- a/src/WallGo/Config/WallGoDefaults.ini
+++ b/src/WallGo/Config/WallGoDefaults.ini
@@ -83,3 +83,10 @@ absoluteTol = 1e-10
 # minimum and maximum temperature obtained in the template model.
 tmax = 1.2
 tmin = 0.8
+
+[BoltzmannSolver]
+# Factor multiplying the collision term in the Boltzmann equation.
+# Can be used for testing or for studying the solution's sensibility
+# to the collision integrals. Don't forget to adjust meanFreePath
+# accordingly if this is different from 1 (meanFreePath ~ 1/collisionMultiplier).
+collisionMultiplier = 1.0

--- a/src/WallGo/Config/WallGoDefaults.ini
+++ b/src/WallGo/Config/WallGoDefaults.ini
@@ -31,6 +31,10 @@ pressRelErrTol = 0.1
 # Maximum number of iterations for the convergence of the pressure
 maxIterations = 20
 
+# Flag to enforce conservation of energy and momentum. 
+# If 1, it is enforced. If 0, it is not.
+conserveEnergyMomentum = 1
+
 # Bounds on wall thickness (in units of 1/Tnucl)
 wallThicknessLowerBound = 0.1
 wallThicknessUpperBound = 100.0

--- a/src/WallGo/boltzmann.py
+++ b/src/WallGo/boltzmann.py
@@ -39,6 +39,7 @@ class BoltzmannSolver:
         basisM: str = "Cardinal",
         basisN: str = "Chebyshev",
         derivatives: str = "Spectral",
+        collisionMultiplier: float = 1.0,
     ):
         """
         Initialisation of BoltzmannSolver
@@ -47,16 +48,19 @@ class BoltzmannSolver:
         ----------
         grid : Grid
             An object of the Grid class.
-        collisionArray : CollisionArray
-            An object of the CollisionArray class containing the collision
             integrals.
-        derivatives : {'Spectral', 'Finite Difference'}
+        basisM : str, optional
+            The position polynomial basis type, either 'Cardinal' or 'Chebyshev'.
+            Default is 'Cardinal'.
+        basisN : str, optional
+            The momentum polynomial basis type, either 'Cardinal' or 'Chebyshev'.
+            Default is 'Chebyshev'.
+        derivatives : {'Spectral', 'Finite Difference'}, optional
             Choice of method for computing derivatives. Default is 'Spectral'
             which is expected to be more accurate.
-        basisM : str
-            The position polynomial basis type, either 'Cardinal' or 'Chebyshev'.
-        basisN : str
-            The momentum polynomial basis type, either 'Cardinal' or 'Chebyshev'.
+        collisionMultiplier : float, optional
+            Factor by which the collision term is multiplied. Can be used for testing.
+            Default is 1.0.
 
         Returns
         -------
@@ -78,6 +82,8 @@ class BoltzmannSolver:
         self.basisM = basisM
         # Momentum polynomial type
         self.basisN = basisN
+        
+        self.collisionMultiplier = collisionMultiplier
 
         # These are set, and can be updated, by our member functions
         # TODO: are these None types the best way to go?
@@ -591,7 +597,7 @@ class BoltzmannSolver:
         """
 
         # including factored-out T^2 in collision integrals
-        collision = (
+        collision = self.collisionMultiplier * (
             (temperature**2)[:, :, :, :, None, None, None, None]
             * intertwinerChiMat[None, :, None, None, None, :, None, None]
             * self.collisionArray[:, None, :, :, :, None, :, :]

--- a/src/WallGo/equationOfMotion.py
+++ b/src/WallGo/equationOfMotion.py
@@ -837,8 +837,9 @@ class EOM:
         velocityProfile = None
         if not self.forceEnergyConservation:
             # If conservation of energy and momentum is not enforced, fix the velocity
-            # and temperature to the following profiles. Otherwise, they will be
-            # evaluated at each iteration.
+            # and temperature to the following profiles, which are the profiles computed
+            # at the first iteration. Otherwise, they will be evaluated at each
+            # iteration.
             temperatureProfile = boltzmannBackground.temperatureProfile[1:-1]
             velocityProfile = boltzmannBackground.velocityProfile[1:-1]
 

--- a/src/WallGo/equationOfMotion.py
+++ b/src/WallGo/equationOfMotion.py
@@ -47,6 +47,7 @@ class EOM:
         wallThicknessBounds: tuple[float, float],
         wallOffsetBounds: tuple[float, float],
         includeOffEq: bool = False,
+        forceEnergyConservation: bool = True,
         forceImproveConvergence: bool = False,
         errTol: float = 1e-3,
         maxIterations: int = 10,
@@ -79,6 +80,9 @@ class EOM:
         includeOffEq : bool, optional
             If False, all the out-of-equilibrium contributions are neglected.
             The default is False.
+        forceEnergyConservation : bool, optional
+            If True, enforce energy-momentum conservation by solving for the appropriate
+            T and vpl profiles. If false, use fixed T and vpl profiles. Default is True.
         forceImproveConvergence : bool, optional
             If True, uses a slower algorithm that improves the convergence when
             computing the pressure. The improved algorithm is automatically used
@@ -112,6 +116,7 @@ class EOM:
         self.wallThicknessBounds = wallThicknessBounds
         self.wallOffsetBounds = wallOffsetBounds
         self.includeOffEq = includeOffEq
+        self.forceEnergyConservation = forceEnergyConservation
         self.forceImproveConvergence = forceImproveConvergence
 
         self.thermo = thermodynamics
@@ -828,6 +833,14 @@ class EOM:
             Tplus,
             Tminus,
         )
+        temperatureProfile = None
+        velocityProfile = None
+        if not self.forceEnergyConservation:
+            # If conservation of energy and momentum is not enforced, fix the velocity
+            # and temperature to the following profiles. Otherwise, they will be
+            # evaluated at each iteration.
+            temperatureProfile = boltzmannBackground.temperatureProfile[1:-1]
+            velocityProfile = boltzmannBackground.velocityProfile[1:-1]
 
         pressures = [pressure]
 
@@ -865,6 +878,8 @@ class EOM:
                     boltzmannResults,
                     Tplus,
                     Tminus,
+                    temperatureProfile=temperatureProfile,
+                    velocityProfile=velocityProfile,
                     multiplier=multiplier,
                 )
             else:
@@ -883,6 +898,8 @@ class EOM:
                     boltzmannResults,
                     Tplus,
                     Tminus,
+                    temperatureProfileInput=temperatureProfile,
+                    velocityProfileInput=velocityProfile,
                     multiplier=multiplier,
                 )
                 errorSolver = 0

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -493,8 +493,15 @@ class WallGoManager:
             gridMomentumFalloffScale,
         )
 
+        collisionMultiplier = self.config.getfloat("BoltzmannSolver",
+                                                   "collisionMultiplier")
         # Hardcode basis types here: Cardinal for z, Chebyshev for pz, pp
-        boltzmannSolver = BoltzmannSolver(grid, basisM="Cardinal", basisN="Chebyshev")
+        boltzmannSolver = BoltzmannSolver(
+            grid,
+            basisM="Cardinal",
+            basisN="Chebyshev",
+            collisionMultiplier=collisionMultiplier,
+            )
 
         boltzmannSolver.updateParticleList(self.model.outOfEquilibriumParticles)
 

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -493,6 +493,7 @@ class WallGoManager:
             gridMomentumFalloffScale,
         )
 
+        # Factor that multiplies the collision term in the Boltzmann equation.
         collisionMultiplier = self.config.getfloat("BoltzmannSolver",
                                                    "collisionMultiplier")
         # Hardcode basis types here: Cardinal for z, Chebyshev for pz, pp

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -604,6 +604,8 @@ class WallGoManager:
         errTol = self.config.getfloat("EquationOfMotion", "errTol")
         maxIterations = self.config.getint("EquationOfMotion", "maxIterations")
         pressRelErrTol = self.config.getfloat("EquationOfMotion", "pressRelErrTol")
+        conserveEnergy = bool(self.config.getint(
+            "EquationOfMotion", "conserveEnergyMomentum"))
 
         wallThicknessBounds = (
             self.config.getfloat("EquationOfMotion", "wallThicknessLowerBound"),
@@ -626,6 +628,7 @@ class WallGoManager:
             wallThicknessBounds,
             wallOffsetBounds,
             includeOffEq=True,
+            forceEnergyConservation=conserveEnergy,
             forceImproveConvergence=False,
             errTol=errTol,
             maxIterations=maxIterations,


### PR DESCRIPTION
Added a flag in the config file to force or not conservation of energy and momentum.
Also added a 'collisionMultiplier' which simply multiplies the collision term in the Boltzmann equation.

Not enforcing conservation of energy-momentum does help a lot in the Yukawa model, but the solutions are still a bit wiggly. I think this is because the collision integrals are very small (see Issue #295). In particular, the annihilation processes are proportional to y^4~1e-3, so the particle number takes a long time to relax to the equilibrium value (meanFreePath has to be set to 1e6). Numerically, this can be solved by increasing collisionMultiplier: the solutions start behaving nicely when it is around 100. But of course this is not justified physically.