### PR TITLE
Fix Inert Doublet Model

### DIFF
--- a/Models/InertDoubletModel/inertDoubletModel.py
+++ b/Models/InertDoubletModel/inertDoubletModel.py
@@ -256,7 +256,7 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
         super().__init__(
             integrals=None,
             useDefaultInterpolation=True,
-            imaginaryOption=EImaginaryOption.ABS_ARGUMENT,
+            imaginaryOption=EImaginaryOption.PRINCIPAL_PART,
         )
 
         assert owningModel is not None, "Invalid model passed to Veff"
@@ -324,10 +324,6 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
             )
         )
 
-        if v == 10.:
-            print(f"{bosonInformation = }")
-            print(f"{potentialTree =} {self.potentialOneLoop(bosonInformation, fermionInformation)=} {self.potentialOneLoopThermal(bosonInformationResummed, fermionInformation, temperature)} {potentialTotal=}")
-
         return np.array(potentialTotal)
 
     def jCW(
@@ -366,10 +362,13 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
             One-loop Coleman-Weinberg potential for given particle spectrum.
         """
 
-        return degreesOfFreedom * np.array(
-            massSq * massSq * (np.log(massSq / rgScale**2) - c)
+        # Note that we are taking the absolute value of the mass in the log here,
+        # instead of using EImaginaryOption = ABS_ARGUMENT, because we do not 
+        # want the absolute value in the product of massSq ans rgScale
+        return degreesOfFreedom*np.array( 
+            massSq * massSq * (np.log(np.abs(massSq / rgScale**2)) - c)
             + 2 * massSq * rgScale**2
-        )
+        ) / (64 * np.pi * np.pi)
 
     def fermionInformation(self, fields: Fields) -> tuple[
         np.ndarray,
@@ -529,8 +528,10 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
         )  # Eq. (16) of 2211.13142 (note the different normalization of lam2)
 
         # Scalar masses including thermal contribution
-        mhsq = msq + 3 * lam * v**2 + piPhi
-        mGsq = msq + lam * v**2 + piPhi  # Goldstone bosons
+        # Need to take the absolute value because we can not
+        # use EImaginaryOption = ABS_ARGUMENT for the full potential
+        mhsq = np.abs(msq + 3 * lam * v**2 + piPhi)
+        mGsq = np.abs(msq + lam * v**2 + piPhi)  # Goldstone bosons
         mHsq = msq2 + (lam3 + lam4 + lam5) / 2 * v**2 + piEta
         mAsq = msq2 + (lam3 + lam4 - lam5) / 2 * v**2 + piEta
         mHpmsq = msq2 + lam3 / 2 * v**2 + piEta

--- a/Models/InertDoubletModel/inertDoubletModel.py
+++ b/Models/InertDoubletModel/inertDoubletModel.py
@@ -256,7 +256,7 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
         super().__init__(
             integrals=None,
             useDefaultInterpolation=True,
-            imaginaryOption=EImaginaryOption.PRINCIPAL_PART,
+            imaginaryOption=EImaginaryOption.ABS_ARGUMENT,
         )
 
         assert owningModel is not None, "Invalid model passed to Veff"
@@ -324,6 +324,10 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
             )
         )
 
+        if v == 10.:
+            print(f"{bosonInformation = }")
+            print(f"{potentialTree =} {self.potentialOneLoop(bosonInformation, fermionInformation)=} {self.potentialOneLoopThermal(bosonInformationResummed, fermionInformation, temperature)} {potentialTotal=}")
+
         return np.array(potentialTotal)
 
     def jCW(
@@ -363,7 +367,7 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
         """
 
         return degreesOfFreedom * np.array(
-            massSq * massSq * (np.log(np.abs(massSq / rgScale**2) + 1e-100) - c)
+            massSq * massSq * (np.log(massSq / rgScale**2) - c)
             + 2 * massSq * rgScale**2
         )
 
@@ -525,8 +529,8 @@ class EffectivePotentialIDM(EffectivePotentialNoResum):
         )  # Eq. (16) of 2211.13142 (note the different normalization of lam2)
 
         # Scalar masses including thermal contribution
-        mhsq = np.abs(msq + 3 * lam * v**2 + piPhi)
-        mGsq = np.abs(msq + lam * v**2 + piPhi)  # Goldstone bosons
+        mhsq = msq + 3 * lam * v**2 + piPhi
+        mGsq = msq + lam * v**2 + piPhi  # Goldstone bosons
         mHsq = msq2 + (lam3 + lam4 + lam5) / 2 * v**2 + piEta
         mAsq = msq2 + (lam3 + lam4 - lam5) / 2 * v**2 + piEta
         mHpmsq = msq2 + lam3 / 2 * v**2 + piEta

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -20,8 +20,6 @@ from .hydrodynamicsTemplateModel import HydrodynamicsTemplateModel
 from .thermodynamics import Thermodynamics
 from .results import WallGoResults
 
-from .fields import Fields
-
 
 @dataclass
 class WallSolverSettings:

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -20,6 +20,8 @@ from .hydrodynamicsTemplateModel import HydrodynamicsTemplateModel
 from .thermodynamics import Thermodynamics
 from .results import WallGoResults
 
+from .fields import Fields
+
 
 @dataclass
 class WallSolverSettings:
@@ -220,6 +222,8 @@ class WallGoManager:
         ) = self.model.getEffectivePotential().findLocalMinimum(
             phaseInput.phaseLocation2, T
         )
+
+        print(f"{self.model.getEffectivePotential().evaluate(Fields([10.]),100.)=}")
 
         print(f"Found phase 1: phi = {phaseLocation1}, Veff(phi) = {effPotValue1}")
         print(f"Found phase 2: phi = {phaseLocation2}, Veff(phi) = {effPotValue2}")

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -223,8 +223,6 @@ class WallGoManager:
             phaseInput.phaseLocation2, T
         )
 
-        print(f"{self.model.getEffectivePotential().evaluate(Fields([10.]),100.)=}")
-
         print(f"Found phase 1: phi = {phaseLocation1}, Veff(phi) = {effPotValue1}")
         print(f"Found phase 2: phi = {phaseLocation2}, Veff(phi) = {effPotValue2}")
 


### PR DESCRIPTION
It turned out that the jCW function of the Inert Doublet Model (which needs to be overwritten to get the same potential as in 2211.13142) was missing a factor 1/(64 pi^2). I also needed to keep some explicit np.abs(massSq) in the bosonInformation function.
Now the file runs happily again.