### PR TITLE
Verbosity

### DIFF
--- a/Models/InertDoubletModel/inertDoubletModel.py
+++ b/Models/InertDoubletModel/inertDoubletModel.py
@@ -738,7 +738,7 @@ class InertDoubletModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """Singlet example uses spatial grid size = 20"""
+        """IDM example uses spatial grid size = 20"""
         super().configureManager(inOutManager)
         inOutManager.config.configGrid.spatialGridSize = 20
 

--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
@@ -300,11 +300,9 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
         thisFileDirectory = os.path.dirname(os.path.abspath(__file__))
         self.integrals.Jb.readInterpolationTable(
             os.path.join(thisFileDirectory, "interpolationTable_Jb_testModel.txt"),
-            bVerbose=False,
         )
         self.integrals.Jf.readInterpolationTable(
             os.path.join(thisFileDirectory, "interpolationTable_Jf_testModel.txt"),
-            bVerbose=False,
         )
 
         self.integrals.Jb.disableAdaptiveInterpolation()

--- a/Models/StandardModel/standardModel.py
+++ b/Models/StandardModel/standardModel.py
@@ -487,7 +487,7 @@ class StandardModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """Singlet example uses spatial grid size = 20"""
+        """SM example uses spatial grid size = 20"""
         super().configureManager(inOutManager)
         inOutManager.config.configGrid.spatialGridSize = 20
 

--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -180,8 +180,6 @@ class EffectivePotentialYukawa(WallGo.EffectivePotential):
         self.owner = owningModel
         self.modelParameters = self.owner.modelParameters
 
-        print(self.modelParameters)
-
     def evaluate(
         self, fields: Fields, temperature: float
     ) -> float | np.ndarray:

--- a/Models/wallGoExampleBase.py
+++ b/Models/wallGoExampleBase.py
@@ -117,8 +117,8 @@ class WallGoExampleBase(ABC):
             "--verbose",
             type=int,
             default=logging.DEBUG,
-            help="""Set the verbosity level. Must an int: DEBUG=10, INFO=20, WARNING=30,
-                     ERROR=40. Default is DEBUG.""",
+            help="""Set the verbosity level. Must be an int: DEBUG=10, INFO=20,
+             WARNING=30, ERROR=40. Default is DEBUG.""",
         )
 
         argParser.add_argument(

--- a/Models/wallGoExampleBase.py
+++ b/Models/wallGoExampleBase.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import copy
 import inspect
 import sys
+import logging
 
 import WallGo
 
@@ -109,6 +110,15 @@ class WallGoExampleBase(ABC):
             default=0,
             help="""Basis size N override for momentum grid. Values less than equal
             to 0 are ignored and we use whatever default the example has defined.""",
+        )
+        
+        argParser.add_argument(
+            "-v",
+            "--verbose",
+            type=int,
+            default=logging.DEBUG,
+            help="""Set the verbosity level. Must an int: DEBUG=10, INFO=20, WARNING=30,
+                     ERROR=40. Default is DEBUG.""",
         )
 
         argParser.add_argument(
@@ -210,6 +220,8 @@ class WallGoExampleBase(ABC):
 
         # Initialise the manager
         manager = WallGo.WallGoManager()
+
+        manager.setVerbosity(self.cmdArgs.verbose)
 
         # Update the configs
         self.configureManager(manager)

--- a/Models/wallGoExampleBase.py
+++ b/Models/wallGoExampleBase.py
@@ -286,7 +286,7 @@ class WallGoExampleBase(ABC):
                 
                 wallSolverSettings.bIncludeOffEquilibrium = False
                 print(
-                    f"\n === Begin EOM with off-eq effects ignored ==="
+                    f"\n=== Begin EOM with off-eq effects ignored ==="
                 )
                 results = manager.solveWall(wallSolverSettings)
                 self.processResultsForBenchmark(benchmark, results)

--- a/src/WallGo/PotentialTools/__init__.py
+++ b/src/WallGo/PotentialTools/__init__.py
@@ -56,11 +56,9 @@ def _initalizeIntegralInterpolations() -> None:  # pylint: disable=invalid-name
 
     defaultIntegrals.Jb.readInterpolationTable(
         getSafePathToResource(config.get("DataFiles", "InterpolationTable_Jb")),
-        bVerbose=False,
     )
     defaultIntegrals.Jf.readInterpolationTable(
         getSafePathToResource(config.get("DataFiles", "InterpolationTable_Jf")),
-        bVerbose=False,
     )
 
 

--- a/src/WallGo/__init__.py
+++ b/src/WallGo/__init__.py
@@ -34,14 +34,13 @@ _bCollisionModuleAvailable: bool = False
 try:
     import WallGoCollision
 
-    print(f"Loaded WallGoCollision package from location: {WallGoCollision.__path__}")
+    #print(f"Loaded WallGoCollision package from location: {WallGoCollision.__path__}")
     _bCollisionModuleAvailable = True  # pylint: disable=invalid-name
 
     from .collisionHelpers import *
 
 except ImportError as e:
-    print(f"Error loading WallGoCollision module: {e}")
-    print(
+    RuntimeWarning(f"Error loading WallGoCollision module: {e}"
         "This could indicate an issue with your installation of WallGo or "
         "WallGoCollision, or both. This is non-fatal, but you will not be able to"
         " utilize collision integration routines."
@@ -75,7 +74,3 @@ def _initializeInternal() -> None:
         _bInitialized = True
     else:
         raise RuntimeWarning("Warning: Repeated call to WallGo._initializeInternal()")
-
-
-"""Initialising WallGo"""
-_initializeInternal()

--- a/src/WallGo/__init__.py
+++ b/src/WallGo/__init__.py
@@ -1,5 +1,7 @@
 """Initialising WallGo package"""
 
+import warnings
+
 # subpackage
 from . import PotentialTools
 
@@ -40,7 +42,7 @@ try:
     from .collisionHelpers import *
 
 except ImportError as e:
-    RuntimeWarning(f"Error loading WallGoCollision module: {e}"
+    warnings.warn(f"Error loading WallGoCollision module: {e}"
         "This could indicate an issue with your installation of WallGo or "
         "WallGoCollision, or both. This is non-fatal, but you will not be able to"
         " utilize collision integration routines."

--- a/src/WallGo/boltzmann.py
+++ b/src/WallGo/boltzmann.py
@@ -5,6 +5,7 @@ Classes for solving the Boltzmann equations for out-of-equilibrium particles.
 import sys
 import typing
 from copy import deepcopy
+import logging
 import numpy as np
 import findiff  # finite difference methods
 from .containers import BoltzmannBackground, BoltzmannDeltas
@@ -635,7 +636,7 @@ class BoltzmannSolver:
                 self.basisN,
                 self.offEqParticles,
             )
-            print(f"Loaded collision data from directory {directoryPath}")
+            logging.debug(f"Loaded collision data from directory {directoryPath}")
         except CollisionLoadError as e:
             raise
 

--- a/src/WallGo/collisionHelpers.py
+++ b/src/WallGo/collisionHelpers.py
@@ -1,5 +1,7 @@
 """Conversion between WallGo and WallGoCollision types"""
 
+import logging
+
 from .particle import Particle
 from .genericModel import GenericModel
 from .exceptions import WallGoError
@@ -28,7 +30,7 @@ def convertParticleStatistics(statisticsName: str) -> WallGoCollision.EParticleT
     elif statisticsName == "Boson":
         return WallGoCollision.EParticleType.eBoson
     else:
-        print(
+        logging.warning(
             f'Invalid particle statistic: {statisticsName}. Must be "Fermion" or "Boson".'
         )
         return WallGoCollision.EParticleType.eNone

--- a/src/WallGo/equationOfMotion.py
+++ b/src/WallGo/equationOfMotion.py
@@ -5,6 +5,7 @@ Class for solving the EOM and the hydrodynamic equations.
 import warnings
 from typing import Tuple
 import copy  # for deepcopy
+import logging
 import numpy as np
 import numpy.typing as npt
 
@@ -178,7 +179,7 @@ class EOM:
             self.hydrodynamics.doesPhaseTraceLimitvmax[0] 
             or self.hydrodynamics.doesPhaseTraceLimitvmax[1]
         ):
-            print(
+            logging.warning(
                 """\n Warning: vmax is limited by the maximum temperature chosen in
                 the phase tracing. WallGo might be unable to find the wall velocity.
                 Try increasing the maximum temperature! \n"""
@@ -456,8 +457,8 @@ class EOM:
         # The pressure peak is not enough to stop the wall: no deflagration or
         # hybrid solution
         if pressureMax < 0:
-            print("Maximum pressure on wall is negative!")
-            print(f"{pressureMax=} {wallParamsMax=}")
+            logging.info("Maximum pressure on wall is negative!")
+            logging.info(f"{pressureMax=} {wallParamsMax=}")
             results.setWallVelocities(None, None, wallVelocityLTE)
             results.setWallParams(wallParamsMax)
             results.setHydroResults(hydroResultsMax)
@@ -494,7 +495,7 @@ class EOM:
             # until it's negative.
             wallVelocityMin *= 2
             if wallVelocityMin >= wallVelocityMax:
-                print(
+                logging.warning(
                     """EOM warning: the pressure at vw = 0 is positive which indicates
                     the phase transition cannot proceed. Something might be wrong with
                     your potential."""
@@ -750,7 +751,7 @@ class EOM:
         if wallVelocity > self.hydrodynamics.vJ:
             improveConvergence = True
 
-        print(f"------------- Trying {wallVelocity=:g} -------------")
+        logging.info(f"------------- Trying {wallVelocity=:g} -------------")
 
         # Initialize the different data class objects and arrays
         zeroPoly = Polynomial(
@@ -856,7 +857,7 @@ class EOM:
         multiplier = 1.0
 
         i = 0
-        print(
+        logging.debug(
             f"{'pressure':>12s} {'error':>12s} {'errorSolver':>12s} {'errTol':>12s} {'cautious':>12s} {'multiplier':>12s}"
         )
         while True:
@@ -909,7 +910,7 @@ class EOM:
             error = np.abs(pressures[-1] - pressures[-2])
             errTol = np.maximum(rtol * np.abs(pressure), atol) * multiplier
 
-            print(
+            logging.debug(
                 f"{pressure:>12g} {error:>12g} {errorSolver:>12g} {errTol:>12g} {improveConvergence:>12} {multiplier:>12g}"
             )
             i += 1
@@ -929,7 +930,7 @@ class EOM:
                 else:
                     break
             elif i >= self.maxIterations - 1:
-                print(
+                logging.warning(
                     "Pressure for a wall velocity has not converged to "
                     "sufficient accuracy with the given maximum number "
                     "for iterations."
@@ -953,7 +954,9 @@ class EOM:
                     # If the error decreases too slowly, use the improved algorithm
                     improveConvergence = True
 
-        print(f"Final {pressure=:g}; Final {wallParams=}")
+        logging.info(f"Final {pressure=:g}")
+        logging.debug(f"Final {wallParams=}")
+        
         return (
             pressure,
             wallParams,

--- a/src/WallGo/freeEnergy.py
+++ b/src/WallGo/freeEnergy.py
@@ -4,6 +4,7 @@ interpolate it.
 """
 
 from dataclasses import dataclass
+import logging
 import numpy as np
 import scipy.integrate as scipyint
 import scipy.linalg as scipylinalg
@@ -336,7 +337,7 @@ class FreeEnergy(InterpolatableFunction):
                 try:
                     ode.step()
                 except RuntimeWarning as error:
-                    print(error.args[0] + f" at T={ode.t}")
+                    logging.error(error.args[0] + f" at T={ode.t}")
                     break
                 if paranoid:
                     phaset, potentialEffT = self.effectivePotential.findLocalMinimum(
@@ -369,7 +370,7 @@ class FreeEnergy(InterpolatableFunction):
                 if ode.step_size < 1e-16 * T0 or (
                     TList.size > 0 and ode.t == TList[-1]
                 ):
-                    print(
+                    logging.warning(
                         f"Step size {ode.step_size} shrunk too small at T={ode.t}, "
                         f"vev={ode.y}"
                     )
@@ -421,7 +422,7 @@ class FreeEnergy(InterpolatableFunction):
             or self.minPossibleTemperature[0]
             > self.startingTemperature - ode.step_size * 10
         ):
-            print(
+            logging.warning(
                 """Warning: the temperature step size seems too large.
                 Try decreasing temperatureVariationScale."""
             )

--- a/src/WallGo/hydrodynamics.py
+++ b/src/WallGo/hydrodynamics.py
@@ -3,6 +3,7 @@ Classes for solving the hydrodynamic equations for the fluid velocity and temper
 """
 
 from typing import Tuple
+import logging
 import numpy as np
 import numpy.typing as npt
 from scipy.optimize import root_scalar, root, minimize_scalar
@@ -69,7 +70,7 @@ class Hydrodynamics:
         try:
             self.vJ = self.findJouguetVelocity()
         except WallGoError:
-            print(
+            logging.warning(
                 "Couldn't find Jouguet velocity, we continue "
                 "with the Jouguet velocity of the template model"
             )
@@ -812,7 +813,7 @@ class Hydrodynamics:
 
         """
         if vwTry < self.vMin:
-            print(
+            logging.warning(
                 "This wall velocity is too small for the chosen nucleation temperature,"
                 " findHydroBoundaries will return zero."
             )

--- a/src/WallGo/hydrodynamicsTemplateModel.py
+++ b/src/WallGo/hydrodynamicsTemplateModel.py
@@ -4,6 +4,7 @@ approximating the equation of state by the template model.
 """
 
 import warnings
+import logging
 import numpy as np
 from scipy.integrate import solve_ivp
 from scipy.optimize import root_scalar, minimize_scalar, OptimizeResult
@@ -566,7 +567,7 @@ class HydrodynamicsTemplateModel:
             to find a solution, returns a tuple of None.
         """
         if vwTry < self.vMin:
-            print(
+            logging.warning(
                 """This wall velocity is too small for the chosen nucleation
                 temperature. findHydroBoundaries will return zero."""
             )

--- a/src/WallGo/interpolatableFunction.py
+++ b/src/WallGo/interpolatableFunction.py
@@ -5,6 +5,7 @@ Class that can be use to evaluate and interpolate functions.
 from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import Callable, Tuple
+import logging
 import numpy as np
 from scipy.interpolate import CubicSpline
 
@@ -662,7 +663,7 @@ class InterpolatableFunction(ABC):
         """
         if not self.hasInterpolation():
             newPoints = int(pointsMin + pointsMax)
-            print(
+            logging.warning(
                 f"Warning: {self.__class__.__name__}.extendInterpolationRange() "
                 "called without existing interpolation. "
                 f"Creating new table in range [{newMin}, {newMax}] with {newPoints} "
@@ -711,7 +712,7 @@ class InterpolatableFunction(ABC):
             self.disableAdaptiveInterpolation()
             self.enableAdaptiveInterpolation()
 
-    def readInterpolationTable(self, fileToRead: str, bVerbose: bool = True) -> None:
+    def readInterpolationTable(self, fileToRead: str) -> None:
         """
         Reads precalculated values from a file and does cubic interpolation.
         Each line in the file must be of form x f(x).
@@ -721,8 +722,6 @@ class InterpolatableFunction(ABC):
         ----------
         fileToRead : str
             Path of the file where the interpolation table is stored.
-        bVerbose : bool, optional
-            Whether or not to print information. The default is True.
 
         """
 
@@ -757,23 +756,20 @@ class InterpolatableFunction(ABC):
             self._validateInterpolationTable(self._rangeMax)
             self._validateInterpolationTable((self._rangeMax - self._rangeMin) / 2.55)
 
-            if bVerbose:
-                print(
-                    f"{selfName}: Succesfully read interpolation table from file. "
-                    "Range [{self._rangeMin}, {self._rangeMax}]"
-                )
+            logging.debug(
+                f"{selfName}: Succesfully read interpolation table from file. "
+                "Range [{self._rangeMin}, {self._rangeMax}]"
+            )
 
         except IOError as ioError:
-            print(
+            logging.warning(
                 f"IOError! {selfName} attempted to read interpolation table from "
                 "file, but got error:"
             )
-            print(ioError)
-            print("This is non-fatal. Interpolation table will not be updated.\n")
+            logging.warning(ioError)
+            logging.warning("This is non-fatal. Interpolation table will not be updated.\n")
 
-    def writeInterpolationTable(
-        self, outputFileName: str, bVerbose: bool = True
-    ) -> None:
+    def writeInterpolationTable(self, outputFileName: str) -> None:
         """
         Write our interpolation table to file.
 
@@ -781,8 +777,6 @@ class InterpolatableFunction(ABC):
         ----------
         outputFileName : str
             Name of the file where the interpolation table will be written.
-        bVerbose : bool, optional
-            Whether or not to print information. The default is True.
 
         """
         try:
@@ -797,14 +791,13 @@ class InterpolatableFunction(ABC):
             )
             np.savetxt(outputFileName, stackedArray, fmt="%.15g", delimiter=" ")
 
-            if bVerbose:
-                print(
-                    "Stored interpolation table for function "
-                    f"{self.__class__.__name__}, output file {outputFileName}."
-                )
+            logging.debug(
+                "Stored interpolation table for function "
+                f"{self.__class__.__name__}, output file {outputFileName}."
+            )
 
         except Exception as e:
-            print(
+            logging.warning(
                 f"Error from {self.__class__.__name__}, function "
                 f"writeInterpolationTable(): {e}"
             )
@@ -823,7 +816,7 @@ class InterpolatableFunction(ABC):
             self._interpolatedFunction is None
             or not self._rangeMin <= x <= self._rangeMax
         ):
-            print(
+            logging.warning(
                 f"{self.__class__.__name__}: _validateInterpolationTable called, "
                 "but no valid interpolation table was found."
             )
@@ -831,7 +824,7 @@ class InterpolatableFunction(ABC):
 
         diff = self.evaluateInterpolation(x) - self._functionImplementation(x)
         if np.any(np.abs(diff) > absoluteTolerance):
-            print(
+            logging.warning(
                 f"{self.__class__.__name__}: Could not validate interpolation table!"
                 f" Value discrepancy was {diff}"
             )

--- a/src/WallGo/mathematicaHelpers.py
+++ b/src/WallGo/mathematicaHelpers.py
@@ -1,5 +1,6 @@
 import subprocess
 import pathlib
+import logging
 
 ## Put common matheamtica and DRalgo related functions here. Common physics/math functions should go into helpers.py
 
@@ -16,7 +17,7 @@ def generateMatrixElementsViaSubprocess(filePath: pathlib.Path) -> None:
 
     except subprocess.CalledProcessError as e:
         # Handle errors in case the command fails
-        print(
+        logging.error(
             "Fatal: Error when generating matrix elements from mathematica via DRalgo"
         )
-        print(e.stderr.decode("utf-8"))
+        logging.error(e.stderr.decode("utf-8"))

--- a/src/WallGo/thermodynamics.py
+++ b/src/WallGo/thermodynamics.py
@@ -4,6 +4,7 @@ for both phases
 """
 
 from typing import Tuple
+import logging
 
 import numpy as np
 import scipy.optimize
@@ -211,12 +212,12 @@ class Thermodynamics:
 
         # tracing phases and ensuring they are stable
         if not self.freeEnergyHigh.hasInterpolation():
-            print(f"Tracing high-T phase: {TMin=}, {TMax=}, {dT=}, {rTol=}")
+            logging.info(f"Tracing high-T phase: {TMin=}, {TMax=}, {dT=}, {rTol=}")
             self.freeEnergyHigh.tracePhase(
                 TMin, TMax, dT, rTol, spinodal=True, paranoid=paranoid
             )
         if not self.freeEnergyLow.hasInterpolation():
-            print("Tracing low-T phase")
+            logging.info("Tracing low-T phase")
             self.freeEnergyLow.tracePhase(
                 TMin, TMax, dT, rTol, spinodal=True, paranoid=paranoid
             )

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -101,6 +101,19 @@ class WallGoManager:
         return self.config.configGrid.momentumGridSize
 
     def setVerbosity(self, verbosityLevel: int) -> None:
+        """
+        Set the verbosity level.
+
+        Parameters
+        ----------
+        verbosityLevel : int
+            Verbosity level. Follows the standard convention of the logging module where
+            DEBUG=10, INFO=20, WARNING=30 and ERROR=40. In WallGo, most of the
+            information is shown at the INFO level. At the DEBUG level, more
+            information about the calculation of the pressure at each iteration is
+            shown.
+
+        """
         logging.basicConfig(format='%(message)s', level=verbosityLevel, force=True)
 
     def setupThermodynamicsHydrodynamics(

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -5,6 +5,7 @@ wall velocity calculation.
 
 from dataclasses import dataclass
 import pathlib
+import logging
 import numpy as np
 
 # WallGo imports
@@ -77,6 +78,8 @@ class WallGoManager:
 
         # Initialise the configs with the default values
         self.config = Config()
+        
+        logging.basicConfig(format='%(message)s', level=logging.INFO, force=True)
 
         # default to working directory
         self.collisionDirectory = pathlib.Path.cwd()
@@ -140,13 +143,13 @@ class WallGoManager:
         self.initTemperatureRange()
 
         ## Should we write these to a result struct?
-        print("Temperature ranges:")
-        print(
+        logging.info("Temperature ranges:")
+        logging.info(
             "High-T phase: TMin = "
             f"{self.thermodynamics.freeEnergyHigh.minPossibleTemperature[0]}, "
             f"TMax = {self.thermodynamics.freeEnergyHigh.maxPossibleTemperature[0]}"
         )
-        print(
+        logging.info(
             "Low-T phase: TMin = "
             f"{self.thermodynamics.freeEnergyLow.minPossibleTemperature[0]}, "
             f"TMax = {self.thermodynamics.freeEnergyLow.maxPossibleTemperature[0]}"
@@ -168,7 +171,7 @@ class WallGoManager:
                 },
             )
 
-        print(f"Jouguet: {self.hydrodynamics.vJ}")
+        logging.info(f"Jouguet: {self.hydrodynamics.vJ}")
         # TODO return some results struct
 
     def isModelValid(self) -> bool:
@@ -221,8 +224,8 @@ class WallGoManager:
             phaseInput.phaseLocation2, T
         )
 
-        print(f"Found phase 1: phi = {phaseLocation1}, Veff(phi) = {effPotValue1}")
-        print(f"Found phase 2: phi = {phaseLocation2}, Veff(phi) = {effPotValue2}")
+        logging.info(f"Found phase 1: phi = {phaseLocation1}, Veff(phi) = {effPotValue1}")
+        logging.info(f"Found phase 2: phi = {phaseLocation2}, Veff(phi) = {effPotValue2}")
 
         if np.allclose(phaseLocation1, phaseLocation2, rtol=1e-05, atol=1e-05):
             raise WallGoPhaseValidationError(
@@ -287,7 +290,7 @@ class WallGoManager:
             # required temperature. We do not solve hydrodynamics inside the bubble, so
             # we are only interested in T- (the temperature right at the wall).
             hydrodynamicsTemplate = HydrodynamicsTemplateModel(self.thermodynamics)
-            print(f"vwLTE in the template model: {hydrodynamicsTemplate.findvwLTE()}")
+            logging.info(f"vwLTE in the template model: {hydrodynamicsTemplate.findvwLTE()}")
 
         except WallGoError as error:
             # Throw new error with more info

--- a/src/WallGo/wallGoManager.py
+++ b/src/WallGo/wallGoManager.py
@@ -78,8 +78,9 @@ class WallGoManager:
 
         # Initialise the configs with the default values
         self.config = Config()
-        
-        logging.basicConfig(format='%(message)s', level=logging.INFO, force=True)
+
+        # Set the default verbosity level to logging.INFO
+        self.setVerbosity(logging.INFO)
 
         # default to working directory
         self.collisionDirectory = pathlib.Path.cwd()
@@ -98,6 +99,9 @@ class WallGoManager:
         Returns the momentum grid size.
         """
         return self.config.configGrid.momentumGridSize
+
+    def setVerbosity(self, verbosityLevel: int) -> None:
+        logging.basicConfig(format='%(message)s', level=verbosityLevel, force=True)
 
     def setupThermodynamicsHydrodynamics(
         self,


### PR DESCRIPTION
Added different verbosity levels in the source code using the standard logging module. The user can change the verbosity level with the function WallGoManager.setVerbosity(). The levels follow the standard logging convention, with logging.DEBUG=10, logging.INFO=20, logging.WARNING=30 and logging.ERROR=40. 

I wasn't sure if the verbosity level should be treated as another config parameter and included in the config file. In the end I didn't choose to code it like that, but I'm open to another opinion.

Most of the information that was previously shown with print() is now at the INFO level. The detail of the pressure calculation (showing the pressure and error at each iteration) is at the DEBUG level. Every message printed when something not expected happens is at the WARNING level. Let me know if you think some of the levels are not appropriate.