### PR TITLE
Explicit Configuration of models

### DIFF
--- a/Models/InertDoubletModel/inertDoubletModel.py
+++ b/Models/InertDoubletModel/inertDoubletModel.py
@@ -738,9 +738,10 @@ class InertDoubletModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """Singlet example uses spatial grid size = 20"""
+        inOutManager.config.loadConfigFromFile(
+            pathlib.Path(self.exampleBaseDirectory / "inertDoubletModelConfig.ini")
+        )
         super().configureManager(inOutManager)
-        inOutManager.config.configGrid.spatialGridSize = 20
 
     def updateModelParameters(
         self, model: "InertDoubletModel", inputParameters: dict[str, float]

--- a/Models/InertDoubletModel/inertDoubletModelConfig.ini
+++ b/Models/InertDoubletModel/inertDoubletModelConfig.ini
@@ -1,0 +1,95 @@
+## Settings for the ManySinglets example.
+
+[Grid]
+# Specify sizes of our polynomials grid. See eq. (34) in 2204.13120
+# M in the paper
+spatialGridSize = 20
+
+# N in the paper
+# MUST BE ODD
+momentumGridSize = 11
+
+# Fraction of grid points inside the wall defined by the interval
+# [-wallThickness+wallCenter, wallThickness+wallCenter] 
+# (see the parameters of Grid3Scales).
+# Should be a number between 0 and 1.
+ratioPointsWall = 0.5
+
+# Smoothing factor of the mapping function (the larger the smoother)
+smoothing = 0.1
+
+[EquationOfMotion]
+# The absolute error tolerance for the wall-velocity result
+errTol = 1e-3
+
+# The parameters for finding the pressure on the wall at a given wall velocity
+# in the file src/WallGo/equationOfMotion.py
+# Relative error tolerance for the pressure
+pressRelErrTol = 0.1
+
+# Maximum number of iterations for the convergence of the pressure
+maxIterations = 20
+
+# Flag to enforce conservation of energy and momentum. 
+# If True, it is enforced. If False, it is not.
+# Normally, this should be set to True, but it can help with numerical stability
+# to set it to False. If True, there is an ambiguity in the separation between
+# f_{eq} and \delta f when the out-of-equilibrium particles form a closed 
+# system (or nearly closed). This can lead to a divergence of the iterative loop.
+conserveEnergyMomentum = True
+
+# Bounds on wall thickness (in units of 1/Tnucl)
+wallThicknessLowerBound = 0.1
+wallThicknessUpperBound = 100.0
+
+# Bounds on wall offset (in units of the corresponding wall widths)
+wallOffsetLowerBound = -10.0
+wallOffsetUpperBound = 10.0
+
+## The following parameters are only used for detonation solutions ##
+
+# Maximal velocity at which the solver will look to find a detonation solution
+vwMaxDeton = 0.99
+
+# Mininal and maximal number of points probed to bracket the detonation roots
+nbrPointsMinDeton = 5
+nbrPointsMaxDeton = 20
+
+# Desired probability of overshooting a root. Must be between 0 and 1.
+# A smaller value will lead to more pressure evaluations (and thus a longer time), but
+# is less likely to miss a root.
+overshootProbDeton = 0.05
+
+[Hydrodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# probed in Hydrodynamics. They are given in units of the nucleation temperature
+tmin = 0.01
+tmax = 10.
+
+# Relative and absolute tolerance used in Hydrodynamics
+relativeTol = 1e-6
+absoluteTol = 1e-10
+
+[Thermodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# used in the phase tracing. They are given in units of the estimates for the 
+# minimum and maximum temperature obtained in the template model.
+tmin = 0.8
+tmax = 1.2
+
+# Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
+phaseTracerTol = 1e-6
+
+[BoltzmannSolver]
+# Factor multiplying the collision term in the Boltzmann equation.
+# Can be used for testing or for studying the solution's sensibility
+# to the collision integrals. Don't forget to adjust meanFreePath
+# accordingly if this is different from 1 (meanFreePath ~ 1/collisionMultiplier).
+# WARNING: THIS CHANGES THE COLLISION TERMS WRT TO THEIR PHYSICAL VALUE
+collisionMultiplier = 1.0
+
+# The position polynomial basis type, either Cardinal or Chebyshev.
+basisM = Cardinal
+
+# The momentum polynomial basis type, either Cardinal or Chebyshev.
+basisN = Chebyshev

--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
@@ -642,9 +642,11 @@ class SingletStandardModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """Singlet example uses spatial grid size = 20"""
+        """We load the configs from a file for this example."""
+        inOutManager.config.loadConfigFromFile(
+            pathlib.Path(self.exampleBaseDirectory / "singletStandardModelZ2Config.ini")
+        )
         super().configureManager(inOutManager)
-        inOutManager.config.configGrid.spatialGridSize = 20
 
     def updateModelParameters(
         self, model: "SingletSMZ2", inputParameters: dict[str, float]

--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2Config.ini
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2Config.ini
@@ -1,0 +1,95 @@
+## Settings for the ManySinglets example.
+
+[Grid]
+# Specify sizes of our polynomials grid. See eq. (34) in 2204.13120
+# M in the paper
+spatialGridSize = 20
+
+# N in the paper
+# MUST BE ODD
+momentumGridSize = 11
+
+# Fraction of grid points inside the wall defined by the interval
+# [-wallThickness+wallCenter, wallThickness+wallCenter] 
+# (see the parameters of Grid3Scales).
+# Should be a number between 0 and 1.
+ratioPointsWall = 0.5
+
+# Smoothing factor of the mapping function (the larger the smoother)
+smoothing = 0.1
+
+[EquationOfMotion]
+# The absolute error tolerance for the wall-velocity result
+errTol = 1e-3
+
+# The parameters for finding the pressure on the wall at a given wall velocity
+# in the file src/WallGo/equationOfMotion.py
+# Relative error tolerance for the pressure
+pressRelErrTol = 0.1
+
+# Maximum number of iterations for the convergence of the pressure
+maxIterations = 20
+
+# Flag to enforce conservation of energy and momentum. 
+# If True, it is enforced. If False, it is not.
+# Normally, this should be set to True, but it can help with numerical stability
+# to set it to False. If True, there is an ambiguity in the separation between
+# f_{eq} and \delta f when the out-of-equilibrium particles form a closed 
+# system (or nearly closed). This can lead to a divergence of the iterative loop.
+conserveEnergyMomentum = True
+
+# Bounds on wall thickness (in units of 1/Tnucl)
+wallThicknessLowerBound = 0.1
+wallThicknessUpperBound = 100.0
+
+# Bounds on wall offset (in units of the corresponding wall widths)
+wallOffsetLowerBound = -10.0
+wallOffsetUpperBound = 10.0
+
+## The following parameters are only used for detonation solutions ##
+
+# Maximal velocity at which the solver will look to find a detonation solution
+vwMaxDeton = 0.99
+
+# Mininal and maximal number of points probed to bracket the detonation roots
+nbrPointsMinDeton = 5
+nbrPointsMaxDeton = 20
+
+# Desired probability of overshooting a root. Must be between 0 and 1.
+# A smaller value will lead to more pressure evaluations (and thus a longer time), but
+# is less likely to miss a root.
+overshootProbDeton = 0.05
+
+[Hydrodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# probed in Hydrodynamics. They are given in units of the nucleation temperature
+tmin = 0.01
+tmax = 10.
+
+# Relative and absolute tolerance used in Hydrodynamics
+relativeTol = 1e-6
+absoluteTol = 1e-10
+
+[Thermodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# used in the phase tracing. They are given in units of the estimates for the 
+# minimum and maximum temperature obtained in the template model.
+tmin = 0.8
+tmax = 1.2
+
+# Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
+phaseTracerTol = 1e-6
+
+[BoltzmannSolver]
+# Factor multiplying the collision term in the Boltzmann equation.
+# Can be used for testing or for studying the solution's sensibility
+# to the collision integrals. Don't forget to adjust meanFreePath
+# accordingly if this is different from 1 (meanFreePath ~ 1/collisionMultiplier).
+# WARNING: THIS CHANGES THE COLLISION TERMS WRT TO THEIR PHYSICAL VALUE
+collisionMultiplier = 1.0
+
+# The position polynomial basis type, either Cardinal or Chebyshev.
+basisM = Cardinal
+
+# The momentum polynomial basis type, either Cardinal or Chebyshev.
+basisN = Chebyshev

--- a/Models/StandardModel/standardModel.py
+++ b/Models/StandardModel/standardModel.py
@@ -487,9 +487,10 @@ class StandardModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """Singlet example uses spatial grid size = 20"""
+        inOutManager.config.loadConfigFromFile(
+            pathlib.Path(self.exampleBaseDirectory / "standardModelConfig.ini")
+        )
         super().configureManager(inOutManager)
-        inOutManager.config.configGrid.spatialGridSize = 20
 
     def updateModelParameters(
         self, model: "StandardModel", inputParameters: dict[str, float]
@@ -549,7 +550,7 @@ class StandardModelExample(WallGoExampleBase):
                         phaseLocation2=WallGo.Fields([valuesTn[i]]),
                     ),
                     WallGo.VeffDerivativeSettings(
-                        temperatureVariationScale=.5, fieldValueVariationScale=[50.0]
+                        temperatureVariationScale=1., fieldValueVariationScale=[50.0]
                     ),
                     WallGo.WallSolverSettings(
                         # we actually do both cases in the common example

--- a/Models/StandardModel/standardModel.py
+++ b/Models/StandardModel/standardModel.py
@@ -549,7 +549,7 @@ class StandardModelExample(WallGoExampleBase):
                         phaseLocation2=WallGo.Fields([valuesTn[i]]),
                     ),
                     WallGo.VeffDerivativeSettings(
-                        temperatureVariationScale=1.0, fieldValueVariationScale=[50.0]
+                        temperatureVariationScale=.5, fieldValueVariationScale=[50.0]
                     ),
                     WallGo.WallSolverSettings(
                         # we actually do both cases in the common example

--- a/Models/StandardModel/standardModelConfig.ini
+++ b/Models/StandardModel/standardModelConfig.ini
@@ -1,0 +1,95 @@
+## Settings for the ManySinglets example.
+
+[Grid]
+# Specify sizes of our polynomials grid. See eq. (34) in 2204.13120
+# M in the paper
+spatialGridSize = 20
+
+# N in the paper
+# MUST BE ODD
+momentumGridSize = 11
+
+# Fraction of grid points inside the wall defined by the interval
+# [-wallThickness+wallCenter, wallThickness+wallCenter] 
+# (see the parameters of Grid3Scales).
+# Should be a number between 0 and 1.
+ratioPointsWall = 0.5
+
+# Smoothing factor of the mapping function (the larger the smoother)
+smoothing = 0.1
+
+[EquationOfMotion]
+# The absolute error tolerance for the wall-velocity result
+errTol = 1e-3
+
+# The parameters for finding the pressure on the wall at a given wall velocity
+# in the file src/WallGo/equationOfMotion.py
+# Relative error tolerance for the pressure
+pressRelErrTol = 0.1
+
+# Maximum number of iterations for the convergence of the pressure
+maxIterations = 20
+
+# Flag to enforce conservation of energy and momentum. 
+# If True, it is enforced. If False, it is not.
+# Normally, this should be set to True, but it can help with numerical stability
+# to set it to False. If True, there is an ambiguity in the separation between
+# f_{eq} and \delta f when the out-of-equilibrium particles form a closed 
+# system (or nearly closed). This can lead to a divergence of the iterative loop.
+conserveEnergyMomentum = True
+
+# Bounds on wall thickness (in units of 1/Tnucl)
+wallThicknessLowerBound = 0.1
+wallThicknessUpperBound = 100.0
+
+# Bounds on wall offset (in units of the corresponding wall widths)
+wallOffsetLowerBound = -10.0
+wallOffsetUpperBound = 10.0
+
+## The following parameters are only used for detonation solutions ##
+
+# Maximal velocity at which the solver will look to find a detonation solution
+vwMaxDeton = 0.99
+
+# Mininal and maximal number of points probed to bracket the detonation roots
+nbrPointsMinDeton = 5
+nbrPointsMaxDeton = 20
+
+# Desired probability of overshooting a root. Must be between 0 and 1.
+# A smaller value will lead to more pressure evaluations (and thus a longer time), but
+# is less likely to miss a root.
+overshootProbDeton = 0.05
+
+[Hydrodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# probed in Hydrodynamics. They are given in units of the nucleation temperature
+tmin = 0.01
+tmax = 10.
+
+# Relative and absolute tolerance used in Hydrodynamics
+relativeTol = 1e-6
+absoluteTol = 1e-10
+
+[Thermodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# used in the phase tracing. They are given in units of the estimates for the 
+# minimum and maximum temperature obtained in the template model.
+tmin = 0.8
+tmax = 1.2
+
+# Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
+phaseTracerTol = 1e-6
+
+[BoltzmannSolver]
+# Factor multiplying the collision term in the Boltzmann equation.
+# Can be used for testing or for studying the solution's sensibility
+# to the collision integrals. Don't forget to adjust meanFreePath
+# accordingly if this is different from 1 (meanFreePath ~ 1/collisionMultiplier).
+# WARNING: THIS CHANGES THE COLLISION TERMS WRT TO THEIR PHYSICAL VALUE
+collisionMultiplier = 1.0
+
+# The position polynomial basis type, either Cardinal or Chebyshev.
+basisM = Cardinal
+
+# The momentum polynomial basis type, either Cardinal or Chebyshev.
+basisN = Chebyshev

--- a/Models/StandardModel/standardModelConfig.ini
+++ b/Models/StandardModel/standardModelConfig.ini
@@ -78,7 +78,7 @@ tmin = 0.8
 tmax = 1.2
 
 # Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
-phaseTracerTol = 1e-6
+phaseTracerTol = 1e-8
 
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.

--- a/Models/StandardModel/standardModelConfig.ini
+++ b/Models/StandardModel/standardModelConfig.ini
@@ -78,7 +78,7 @@ tmin = 0.8
 tmax = 1.2
 
 # Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
-phaseTracerTol = 1e-8
+phaseTracerTol = 1e-6
 
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.

--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -340,23 +340,10 @@ class YukawaModelExample(WallGoExampleBase):
         inOutCollisionTensor.setIntegrationVerbosity(verbosity)
 
     def configureManager(self, inOutManager: "WallGo.WallGoManager") -> None:
-        """
-        Yukawa example uses spatial grid size = 50.
-        """
+        inOutManager.config.loadConfigFromFile(
+            pathlib.Path(self.exampleBaseDirectory / "yukawaConfig.ini")
+        )
         super().configureManager(inOutManager)
-        
-        # Increase the number of grid points to increase stability
-        inOutManager.config.configGrid.spatialGridSize = 50
-        
-        # Note that if all degrees of freedom are treated as out-of-equilibrium,
-        # this creates a degeneracy in the definition of f_{eq} vs \delta f
-        # If we enforce conservation of EM, this can lead to a divergence of the
-        # iteration procedure. But here the scalar is treated as in-equilibrium,
-        # so we do impose conserveEnergyMomentum.
-        inOutManager.config.configEOM.conserveEnergyMomentum = True
-        
-        # Decrease the phase tracer tolerance to improve stability
-        inOutManager.config.configThermodynamics.phaseTracerTol = 1e-8
 
     def updateModelParameters(
         self, model: "YukawaModel", inputParameters: dict[str, float]

--- a/Models/Yukawa/yukawaConfig.ini
+++ b/Models/Yukawa/yukawaConfig.ini
@@ -1,0 +1,95 @@
+## Settings for the ManySinglets example.
+
+[Grid]
+# Specify sizes of our polynomials grid. See eq. (34) in 2204.13120
+# M in the paper
+spatialGridSize = 50
+
+# N in the paper
+# MUST BE ODD
+momentumGridSize = 11
+
+# Fraction of grid points inside the wall defined by the interval
+# [-wallThickness+wallCenter, wallThickness+wallCenter] 
+# (see the parameters of Grid3Scales).
+# Should be a number between 0 and 1.
+ratioPointsWall = 0.5
+
+# Smoothing factor of the mapping function (the larger the smoother)
+smoothing = 0.1
+
+[EquationOfMotion]
+# The absolute error tolerance for the wall-velocity result
+errTol = 1e-3
+
+# The parameters for finding the pressure on the wall at a given wall velocity
+# in the file src/WallGo/equationOfMotion.py
+# Relative error tolerance for the pressure
+pressRelErrTol = 0.1
+
+# Maximum number of iterations for the convergence of the pressure
+maxIterations = 20
+
+# Flag to enforce conservation of energy and momentum. 
+# If True, it is enforced. If False, it is not.
+# Normally, this should be set to True, but it can help with numerical stability
+# to set it to False. If True, there is an ambiguity in the separation between
+# f_{eq} and \delta f when the out-of-equilibrium particles form a closed 
+# system (or nearly closed). This can lead to a divergence of the iterative loop.
+conserveEnergyMomentum = True
+
+# Bounds on wall thickness (in units of 1/Tnucl)
+wallThicknessLowerBound = 0.1
+wallThicknessUpperBound = 100.0
+
+# Bounds on wall offset (in units of the corresponding wall widths)
+wallOffsetLowerBound = -10.0
+wallOffsetUpperBound = 10.0
+
+## The following parameters are only used for detonation solutions ##
+
+# Maximal velocity at which the solver will look to find a detonation solution
+vwMaxDeton = 0.99
+
+# Mininal and maximal number of points probed to bracket the detonation roots
+nbrPointsMinDeton = 5
+nbrPointsMaxDeton = 20
+
+# Desired probability of overshooting a root. Must be between 0 and 1.
+# A smaller value will lead to more pressure evaluations (and thus a longer time), but
+# is less likely to miss a root.
+overshootProbDeton = 0.05
+
+[Hydrodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# probed in Hydrodynamics. They are given in units of the nucleation temperature
+tmin = 0.01
+tmax = 10.
+
+# Relative and absolute tolerance used in Hydrodynamics
+relativeTol = 1e-6
+absoluteTol = 1e-10
+
+[Thermodynamics]
+# The following two parameters set the minimum and maximum temperature that is
+# used in the phase tracing. They are given in units of the estimates for the 
+# minimum and maximum temperature obtained in the template model.
+tmin = 0.8
+tmax = 1.2
+
+# Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
+phaseTracerTol = 1e-8
+
+[BoltzmannSolver]
+# Factor multiplying the collision term in the Boltzmann equation.
+# Can be used for testing or for studying the solution's sensibility
+# to the collision integrals. Don't forget to adjust meanFreePath
+# accordingly if this is different from 1 (meanFreePath ~ 1/collisionMultiplier).
+# WARNING: THIS CHANGES THE COLLISION TERMS WRT TO THEIR PHYSICAL VALUE
+collisionMultiplier = 1.0
+
+# The position polynomial basis type, either Cardinal or Chebyshev.
+basisM = Cardinal
+
+# The momentum polynomial basis type, either Cardinal or Chebyshev.
+basisN = Chebyshev


### PR DESCRIPTION
Added a model-specific configuration file for the following models: xSM, inert doublet, Yukawa and Standard Model. Benoit already created it for manySinglets.

I took the default settings and modified those whenever the old model file would overwrite those.

The purpose of this PR is to keep the performance of the model files fixed, even if the default values of the configuration parameters change.