### PR TITLE
added bShouldRecalculateMatrixElements flag to all model files

### DIFF
--- a/Models/InertDoubletModel/inertDoubletModel.py
+++ b/Models/InertDoubletModel/inertDoubletModel.py
@@ -621,6 +621,8 @@ class InertDoubletModelExample(WallGoExampleBase):
 
     def __init__(self) -> None:
         """"""
+        self.bShouldRecalculateMatrixElements = False
+
         self.bShouldRecalculateCollisions = False
         self.matrixElementFile = pathlib.Path(
             self.exampleBaseDirectory / "MatrixElements/matrixElements.ew.json"

--- a/Models/ManySinglets/manySinglets.py
+++ b/Models/ManySinglets/manySinglets.py
@@ -538,6 +538,7 @@ class NSingletsModelExample(WallGoExampleBase):
 
     def __init__(self) -> None:
         """"""
+        self.bShouldRecalculateMatrixElements = False
         self.bShouldRecalculateCollisions = False
 
         self.matrixElementFile = pathlib.Path(

--- a/Models/SimpleModel/simpleModelWithCollisionGeneration.py
+++ b/Models/SimpleModel/simpleModelWithCollisionGeneration.py
@@ -39,6 +39,8 @@ class SimpleModelExample(WallGoExampleBase):
 
     def __init__(self) -> None:
         """"""
+        self.bShouldRecalculateMatrixElements = False
+
         self.bShouldRecalculateCollisions = False
 
         # We take the matrix elements from the Yukawa model

--- a/Models/StandardModel/standardModel.py
+++ b/Models/StandardModel/standardModel.py
@@ -372,6 +372,7 @@ class StandardModelExample(WallGoExampleBase):
 
     def __init__(self) -> None:
         """"""
+        self.bShouldRecalculateMatrixElements = False
         self.bShouldRecalculateCollisions = False
         self.matrixElementFile = pathlib.Path(
             self.exampleBaseDirectory / "MatrixElements/matrixElements.ew.json"

--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -236,6 +236,8 @@ class YukawaModelExample(WallGoExampleBase):
 
     def __init__(self) -> None:
         """"""
+        self.bShouldRecalculateMatrixElements = False
+
         self.bShouldRecalculateCollisions = False
 
         self.matrixElementFile = pathlib.Path(


### PR DESCRIPTION
The model files broke after https://github.com/Wall-Go/WallGo/pull/303
Just added a flag in all model definitions to repair them.