### PR TITLE
TestPyPI to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
 
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/project/WallGo/
+      name: pypi
+      url: https://pypi.org/p/WallGo/
     permissions:
       id-token: write
 
@@ -33,5 +33,4 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
         verbose: true


### PR DESCRIPTION
Minor changes to release.yml to replace the TestPyPI server with the PyPI server. The differences are explained here:
https://github.com/pypa/gh-action-pypi-publish. Note there is no need to put a url for the PyPI server at the end of the file as this is the default (previously the default was overridden with the TestPyPI server).