### PR TITLE
Restoring main tests, needed for 'Passing' icon on GitHub README.md

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
-name: WallGo tests
+name: WallGo main tests
 
 on:
-  # Note that this workflow is in a separate file from main.yml so that
-  # the PR tests are separate from testing if the current main branch passes.
-  pull_request:
-  workflow_dispatch:
+  push:
+    # Note that this workflow is in a separate file from tests.yml so that
+    # it can be separated out, and used for the [passing] badge on the README.md
+    branches: [ main ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # WallGo
 
-Home: https://wall-go.github.io/WallGo
+Home: https://wallgo.readthedocs.io
 
 License: [GPL3](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Development: https://github.com/Wall-Go/WallGo
 
 [![Version](https://img.shields.io/github/v/tag/Wall-Go/WallGo?label=Version)](https://github.com/Wall-Go/WallGo/tags/)
 
-[![WallGo tests](https://github.com/Wall-Go/WallGo/actions/workflows/main.yml/badge.svg)](https://github.com/Wall-Go/WallGo/actions/workflows/main.yml)
+[![WallGo tests (main)](https://github.com/Wall-Go/WallGo/actions/workflows/main.yml/badge.svg)](https://github.com/Wall-Go/WallGo/actions/workflows/main.yml)
 
 ## About this project
 


### PR DESCRIPTION
I dumped the `main.yml` workflow recently in error, which led to the [passing] icon on the README breaking. This workflow's purpose is to test the current main branch, and therefore give the [passing] icon on the README.md. For this reason it is separate from the `tests.yml` workflow, which is for testing PRs, and which can obviously fail on new PRs which aren't ready to merge.