### PR TITLE
Fix the initial step size of the phase tracer to dT

### DIFF
--- a/src/WallGo/freeEnergy.py
+++ b/src/WallGo/freeEnergy.py
@@ -332,6 +332,7 @@ class FreeEnergy(InterpolatableFunction):
                 rtol=rTol,
                 atol=tolAbsolute,
                 max_step=dT,
+                first_step=dT,
             )
             while ode.status == "running":
                 try:


### PR DESCRIPTION
Tiny PR to fix the initial step size of the phase tracer to dT. This ensure that the initial step size is not too small, which could cause imprecise sound speeds.