### PR TITLE
Removed import of PotentialTools in WallGo/__init__.py

### DIFF
--- a/src/WallGo/__init__.py
+++ b/src/WallGo/__init__.py
@@ -2,9 +2,6 @@
 
 import warnings
 
-# subpackage
-from . import PotentialTools
-
 # package level modules
 from .boltzmann import BoltzmannSolver
 from .collisionArray import CollisionArray

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,3 +4,8 @@
 def test_importWallGo() -> None:
     """Testing import of WallGo"""
     import WallGo
+
+
+def test_importPotentialTools() -> None:
+    """Testing import of WallGo.PotentialTools"""
+    import WallGo.PotentialTools


### PR DESCRIPTION
This PR is trying to fix recent test failures related to importing PotentialTools.

The first attempt at fixing it is simply to remove the import of PotentialTools in `WallGo/__init__.py`. Further options include defining `__getattr__` to do the import later, as is done in numpy, https://github.com/numpy/numpy/blob/v2.1.0/numpy/__init__.py.