### PR TITLE
Phase tracing options

### DIFF
--- a/Models/InertDoubletModel/inertDoubletModelConfig.ini
+++ b/Models/InertDoubletModel/inertDoubletModelConfig.ini
@@ -80,6 +80,9 @@ tmax = 1.2
 # Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
 phaseTracerTol = 1e-8
 
+# First step size in units of the maximum step size. Use None for default algorithm.
+phaseTracerFirstStep = None
+
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.
 # Can be used for testing or for studying the solution's sensibility

--- a/Models/ManySinglets/manySingletsConfig.ini
+++ b/Models/ManySinglets/manySingletsConfig.ini
@@ -80,6 +80,9 @@ tmax = 1.2
 # Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
 phaseTracerTol = 1e-6
 
+# First step size in units of the maximum step size. Use None for default algorithm.
+phaseTracerFirstStep = None
+
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.
 # Can be used for testing or for studying the solution's sensibility

--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2Config.ini
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2Config.ini
@@ -80,6 +80,9 @@ tmax = 1.2
 # Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
 phaseTracerTol = 1e-6
 
+# First step size in units of the maximum step size. Use None for default algorithm.
+phaseTracerFirstStep = None
+
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.
 # Can be used for testing or for studying the solution's sensibility

--- a/Models/StandardModel/standardModel.py
+++ b/Models/StandardModel/standardModel.py
@@ -550,7 +550,7 @@ class StandardModelExample(WallGoExampleBase):
                         phaseLocation2=WallGo.Fields([valuesTn[i]]),
                     ),
                     WallGo.VeffDerivativeSettings(
-                        temperatureVariationScale=1.0, fieldValueVariationScale=[50.0]
+                        temperatureVariationScale=0.75, fieldValueVariationScale=[50.0]
                     ),
                     WallGo.WallSolverSettings(
                         # we actually do both cases in the common example

--- a/Models/StandardModel/standardModel.py
+++ b/Models/StandardModel/standardModel.py
@@ -550,7 +550,7 @@ class StandardModelExample(WallGoExampleBase):
                         phaseLocation2=WallGo.Fields([valuesTn[i]]),
                     ),
                     WallGo.VeffDerivativeSettings(
-                        temperatureVariationScale=0.75, fieldValueVariationScale=[50.0]
+                        temperatureVariationScale=1.0, fieldValueVariationScale=[50.0]
                     ),
                     WallGo.WallSolverSettings(
                         # we actually do both cases in the common example

--- a/Models/StandardModel/standardModelConfig.ini
+++ b/Models/StandardModel/standardModelConfig.ini
@@ -80,6 +80,9 @@ tmax = 1.2
 # Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
 phaseTracerTol = 1e-6
 
+# First step size in units of the maximum step size. Use None for default algorithm.
+phaseTracerFirstStep = 1.0
+
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.
 # Can be used for testing or for studying the solution's sensibility

--- a/Models/StandardModel/standardModelConfig.ini
+++ b/Models/StandardModel/standardModelConfig.ini
@@ -81,7 +81,7 @@ tmax = 1.2
 phaseTracerTol = 1e-6
 
 # First step size in units of the maximum step size. Use None for default algorithm.
-phaseTracerFirstStep = 1.0
+phaseTracerFirstStep = None
 
 [BoltzmannSolver]
 # Factor multiplying the collision term in the Boltzmann equation.

--- a/src/WallGo/config.py
+++ b/src/WallGo/config.py
@@ -269,7 +269,19 @@ class Config:
             if 'phaseTracerTol' in keys:
                 self.configThermodynamics.phaseTracerTol = parser.getfloat(
                     "Thermodynamics",
-                    "phaseTracerTol")
+                    "phaseTracerTol"
+                )
+            if 'phaseTracerFirstStep' in keys:
+                # either float or None
+                try:
+                    self.configThermodynamics.phaseTracerFirstStep = parser.getfloat(
+                        "Thermodynamics", "phaseTracerFirstStep"
+                    )
+                except ValueError as valErr:
+                    if str(valErr) == "could not convert string to float: 'None'":
+                        self.configThermodynamics.phaseTracerFirstStep = None
+                    else:
+                        raise
 
         # Read the BoltzmannSolver configs
         if 'BoltzmannSolver' in parser.sections():

--- a/src/WallGo/config.py
+++ b/src/WallGo/config.py
@@ -112,6 +112,13 @@ class ConfigThermodynamics:
     Desired accuracy of the phase tracer and the resulting FreeEnergy interpolation.
     """
 
+    phaseTracerFirstStep: float | None = None
+    r"""
+    Starting step for phaseTrace. If a float, this gives the starting step
+    size in units of the maximum step size :py:data:`dT`. If :py:data:`None` then
+    uses the initial step size algorithm of :py:mod:`scipy.integrate.solve_ivp`.
+    """
+
 @dataclass
 class ConfigBoltzmannSolver:
     """ Holds the config of the BoltzmannSolver class. """

--- a/src/WallGo/freeEnergy.py
+++ b/src/WallGo/freeEnergy.py
@@ -330,7 +330,7 @@ class FreeEnergy(InterpolatableFunction):
         TMax = min(self.maxPossibleTemperature[0], TMax)
 
         # kwargs for scipy.integrate.solve_ivp
-        kwargsScipy = {
+        scipyKwargs = {
             "rtol": rTol,
             "atol": tolAbsolute,
             "max_step": dT,
@@ -338,7 +338,7 @@ class FreeEnergy(InterpolatableFunction):
         }
         if scipyOptions is not None:
             for key in scipyOptions:
-                kwargsScipy[key] = scipyOptions[key]
+                scipyKwargs[key] = scipyOptions[key]
 
         # iterating over up and down integration directions
         endpoints = [TMax, TMin]
@@ -349,7 +349,7 @@ class FreeEnergy(InterpolatableFunction):
                 T0,
                 phase0,
                 TEnd,
-                **kwargsScipy,
+                **scipyKwargs,
             )
             while ode.status == "running":
                 try:

--- a/src/WallGo/freeEnergy.py
+++ b/src/WallGo/freeEnergy.py
@@ -2,7 +2,7 @@
 Class that does phase tracing, computes the effective potential in the minimum and
 interpolate it.
 """
-
+import types
 from dataclasses import dataclass
 import logging
 import numpy as np
@@ -246,7 +246,7 @@ class FreeEnergy(InterpolatableFunction):
         rTol: float = 1e-6,
         spinodal: bool = True,  # Stop tracing if a mass squared turns negative
         paranoid: bool = True,  # Re-solve minimum after every step
-        scipyOptions: dict = {},  # Additional options to pass to scipy.integrate.RK45
+        scipyOptions: dict | None = None,  # scipy.integrate.RK45 options
     ) -> None:
         r"""Traces minimum of potential
 
@@ -273,7 +273,8 @@ class FreeEnergy(InterpolatableFunction):
         paranoid : bool, optional
             If True, re-solve minimum after every step. The default is True.
         scipyOptions : dict, optional
-            Options to pass to `scipy.integrate.RK45` for the phase tracing.
+            Options to pass to `scipy.integrate.RK45` for the phase tracing. For more
+            details, see the `scipy documentation <https://docs.scipy.org>`_.
 
         """
         # make sure the initial conditions are extra accurate
@@ -333,10 +334,11 @@ class FreeEnergy(InterpolatableFunction):
             "rtol": rTol,
             "atol": tolAbsolute,
             "max_step": dT,
-            "first_step": dT,
+            "first_step": None,
         }
-        for key in scipyOptions:
-            kwargsScipy[key] = scipyOptions[key]
+        if scipyOptions is not None:
+            for key in scipyOptions:
+                kwargsScipy[key] = scipyOptions[key]
 
         # iterating over up and down integration directions
         endpoints = [TMax, TMin]

--- a/src/WallGo/freeEnergy.py
+++ b/src/WallGo/freeEnergy.py
@@ -2,7 +2,6 @@
 Class that does phase tracing, computes the effective potential in the minimum and
 interpolate it.
 """
-import types
 from dataclasses import dataclass
 import logging
 import numpy as np

--- a/src/WallGo/freeEnergy.py
+++ b/src/WallGo/freeEnergy.py
@@ -246,7 +246,7 @@ class FreeEnergy(InterpolatableFunction):
         rTol: float = 1e-6,
         spinodal: bool = True,  # Stop tracing if a mass squared turns negative
         paranoid: bool = True,  # Re-solve minimum after every step
-        scipyOptions: dict | None = None,  # scipy.integrate.RK45 options
+        phaseTracerFirstStep: float | None = None,  # Starting step
     ) -> None:
         r"""Traces minimum of potential
 
@@ -267,15 +267,13 @@ class FreeEnergy(InterpolatableFunction):
         dT : float
             Maximal temperature step size used by the phase tracer.
         rTol : float, optional
-            Relative tolerance of the phase tracing. The default is 1e-6.
+            Relative tolerance of the phase tracing. The default is :py:const:`1e-6`.
         spinodal : bool, optional
             If True, stop tracing if a mass squared turns negative. The default is True.
         paranoid : bool, optional
             If True, re-solve minimum after every step. The default is True.
-        scipyOptions : dict, optional
-            Options to pass to `scipy.integrate.RK45` for the phase tracing. For more
-            details, see the `scipy documentation <https://docs.scipy.org>`_.
-
+        phaseTracerFirstStep : float or None, optional
+            If a float, this gives the starting step size in units of the maximum step size :py:data:`dT`. If :py:data:`None` then uses the initial step size algorithm of :py:mod:`scipy.integrate.solve_ivp`. Default is :py:data:`None`
         """
         # make sure the initial conditions are extra accurate
         extraTol = 0.01 * rTol
@@ -334,11 +332,8 @@ class FreeEnergy(InterpolatableFunction):
             "rtol": rTol,
             "atol": tolAbsolute,
             "max_step": dT,
-            "first_step": None,
+            "first_step": phaseTracerFirstStep,
         }
-        if scipyOptions is not None:
-            for key in scipyOptions:
-                scipyKwargs[key] = scipyOptions[key]
 
         # iterating over up and down integration directions
         endpoints = [TMax, TMin]

--- a/src/WallGo/manager.py
+++ b/src/WallGo/manager.py
@@ -351,7 +351,7 @@ class WallGoManager:
 
         """Since the template model is an approximation of the full model, 
         and since the temperature profile in the wall could be non-monotonous,
-        we should not t ake exactly the TMin and TMax from the template model.
+        we should not take exactly the TMin and TMax from the template model.
         We use a configuration parameter to determine the TMin and TMax that we
         use in the phase tracing.
         """
@@ -379,7 +379,7 @@ class WallGoManager:
             phaseTracerFirstStep=self.config.configThermodynamics.phaseTracerFirstStep,
         )
 
-    def setPathToCollisionData(self, directoryPath: pathlib.Path) -> None:
+    def setPathToCollisionData(selft ake, directoryPath: pathlib.Path) -> None:
         """
         Specify path to collision files for use with the Boltzmann solver.
         This does not necessarily load the files immediately.

--- a/src/WallGo/manager.py
+++ b/src/WallGo/manager.py
@@ -379,7 +379,7 @@ class WallGoManager:
             phaseTracerFirstStep=self.config.configThermodynamics.phaseTracerFirstStep,
         )
 
-    def setPathToCollisionData(selft ake, directoryPath: pathlib.Path) -> None:
+    def setPathToCollisionData(self, directoryPath: pathlib.Path) -> None:
         """
         Specify path to collision files for use with the Boltzmann solver.
         This does not necessarily load the files immediately.

--- a/src/WallGo/manager.py
+++ b/src/WallGo/manager.py
@@ -277,7 +277,7 @@ class WallGoManager:
 
         self.phasesAtTn = foundPhaseInfo
 
-    def initTemperatureRange(self, scipyOptions: dict = {}) -> None:
+    def initTemperatureRange(self) -> None:
         """
         Determine the relevant temperature range and trace the phases
         over this range. Interpolate the free energy in both phases and

--- a/src/WallGo/manager.py
+++ b/src/WallGo/manager.py
@@ -351,7 +351,7 @@ class WallGoManager:
 
         """Since the template model is an approximation of the full model, 
         and since the temperature profile in the wall could be non-monotonous,
-        we should not take exactly the TMin and TMax from the template model.
+        we should not t ake exactly the TMin and TMax from the template model.
         We use a configuration parameter to determine the TMin and TMax that we
         use in the phase tracing.
         """
@@ -364,8 +364,20 @@ class WallGoManager:
         fHighT = self.thermodynamics.freeEnergyHigh
         fLowT = self.thermodynamics.freeEnergyLow
 
-        fHighT.tracePhase(TMinHighT, TMaxHighT, dT, phaseTracerTol)
-        fLowT.tracePhase(TMinLowT, TMaxLowT, dT, phaseTracerTol)
+        fHighT.tracePhase(
+            TMinHighT,
+            TMaxHighT,
+            dT,
+            rTol=phaseTracerTol,
+            phaseTracerFirstStep=self.config.configThermodynamics.phaseTracerFirstStep,
+        )
+        fLowT.tracePhase(
+            TMinLowT,
+            TMaxLowT,
+            dT,
+            rTol=phaseTracerTol,
+            phaseTracerFirstStep=self.config.configThermodynamics.phaseTracerFirstStep,
+        )
 
     def setPathToCollisionData(self, directoryPath: pathlib.Path) -> None:
         """

--- a/src/WallGo/manager.py
+++ b/src/WallGo/manager.py
@@ -277,7 +277,7 @@ class WallGoManager:
 
         self.phasesAtTn = foundPhaseInfo
 
-    def initTemperatureRange(self) -> None:
+    def initTemperatureRange(self, scipyOptions: dict = {}) -> None:
         """
         Determine the relevant temperature range and trace the phases
         over this range. Interpolate the free energy in both phases and


### PR DESCRIPTION
Added one option for setting the first step size in phase tracing. Option can be fixed with config.
```
 phaseTracerFirstStep: float | None = None
  r"""
  Starting step for phaseTrace. If a float, this gives the starting step
  size in units of the maximum step size :py:data:`dT`. If :py:data:`None` then
  uses the initial step size algorithm of :py:mod:`scipy.integrate.solve_ivp`.
  """
```

In the model files, I've put the option to `None` for all the models except the Standard Model, where I have set it to `1.0`. Is this correct? I couldn't quite remember.