### PR TITLE
Fix interpolation warning

### DIFF
--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
@@ -55,26 +55,6 @@ if TYPE_CHECKING:
     import WallGoCollision
 
 
-class _InterpolationWarningCatcher(logging.Handler):
-    """Capture interpolation table validation warnings for conditional handling."""
-
-    def __init__(self) -> None:
-        super().__init__(level=logging.WARNING)
-        self.messages: list[str] = []
-
-    def emit(self, record: logging.LogRecord) -> None:
-        message = record.getMessage()
-        if "Could not validate interpolation table" in message:
-            self.messages.append(message)
-
-
-class _SuppressInterpolationValidationWarningFilter(logging.Filter):
-    """Temporarily suppress targeted validation warnings from normal handlers."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        return "Could not validate interpolation table" not in record.getMessage()
-
-
 class SingletSMZ2(GenericModel):
     r"""
     Z2 symmetric SM + singlet model.
@@ -317,33 +297,13 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
         # Since our benchmark tables have no entry for the imaginary part, we
         # will get such a warning. For imaginaryOptions PRINCIPAL_PART and ABS_ARGUMENT,
         # only the real part is relevant, so we can suppress the warning.
-        warningCatcher = _InterpolationWarningCatcher()
-        suppressFilter = _SuppressInterpolationValidationWarningFilter()
-        rootLogger = logging.getLogger()
-
-        # Suppress immediate printing of the specific validation warning while still
-        # capturing it in warningCatcher for conditional handling below.
-        filteredHandlers: list[logging.Handler] = []
-        for handler in rootLogger.handlers:
-            handler.addFilter(suppressFilter)
-            filteredHandlers.append(handler)
-
-        rootLogger.addHandler(warningCatcher)
-        try:
-            self.integrals.Jb.readInterpolationTable(
-                os.path.join(thisFileDirectory, "interpolationTable_Jb_testModel.txt"),
-            )
-            self.integrals.Jf.readInterpolationTable(
-                os.path.join(thisFileDirectory, "interpolationTable_Jf_testModel.txt"),
-            )
-        finally:
-            rootLogger.removeHandler(warningCatcher)
-            for handler in filteredHandlers:
-                handler.removeFilter(suppressFilter)
+        warnings = self._readInterpolationTablesWithCapturedValidationWarnings(
+            thisFileDirectory
+        )
 
         # Check if any warnings were captured. If so, check the real part
         # separately, and only print a warning if it does not validate.
-        self._handleInterpolationValidationWarnings(warningCatcher.messages)
+        self._handleInterpolationValidationWarnings(warnings)
 
         self.integrals.Jb.disableAdaptiveInterpolation()
         self.integrals.Jf.disableAdaptiveInterpolation()
@@ -377,20 +337,60 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
         }
 
         if self.imaginaryOption not in allowedImaginaryOptions:
-            for warningMessage in warnings:
-                logging.warning(warningMessage)
+            self._logWarnings(warnings)
             return
 
-        # For principal-part and abs-argument workflows, only the real part is needed.
-        realPartValid = True
+        # Check if the real part validates.
+        realPartChecks: list[bool] = []
         if any("JbIntegral" in warningMessage for warningMessage in warnings):
-            realPartValid = realPartValid and self._validateFirstColumn(self.integrals.Jb)
+            realPartChecks.append(self._validateFirstColumn(self.integrals.Jb))
         if any("JfIntegral" in warningMessage for warningMessage in warnings):
-            realPartValid = realPartValid and self._validateFirstColumn(self.integrals.Jf)
+            realPartChecks.append(self._validateFirstColumn(self.integrals.Jf))
 
-        if not realPartValid:
-            for warningMessage in warnings:
-                logging.warning(warningMessage)
+        if not all(realPartChecks):
+            self._logWarnings(warnings)
+
+    def _readInterpolationTablesWithCapturedValidationWarnings(
+        self, thisFileDirectory: str
+    ) -> list[str]:
+        """Read benchmark interpolation tables while capturing validation warnings."""
+        warningNeedle = "Could not validate interpolation table"
+        warnings: list[str] = []
+        rootLogger = logging.getLogger()
+
+        class _WarningCaptureHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                message = record.getMessage()
+                if warningNeedle in message:
+                    warnings.append(message)
+
+        def suppressValidationWarning(record: logging.LogRecord) -> bool:
+            return warningNeedle not in record.getMessage()
+
+        captureHandler = _WarningCaptureHandler(level=logging.WARNING)
+        filteredHandlers = list(rootLogger.handlers)
+        for handler in filteredHandlers:
+            handler.addFilter(suppressValidationWarning)
+
+        rootLogger.addHandler(captureHandler)
+        try:
+            self.integrals.Jb.readInterpolationTable(
+                os.path.join(thisFileDirectory, "interpolationTable_Jb_testModel.txt"),
+            )
+            self.integrals.Jf.readInterpolationTable(
+                os.path.join(thisFileDirectory, "interpolationTable_Jf_testModel.txt"),
+            )
+        finally:
+            rootLogger.removeHandler(captureHandler)
+            for handler in filteredHandlers:
+                handler.removeFilter(suppressValidationWarning)
+
+        return warnings
+
+    @staticmethod
+    def _logWarnings(warnings: list[str]) -> None:
+        for warningMessage in warnings:
+            logging.warning(warningMessage)
 
     @staticmethod
     def _validateFirstColumn(integral: Any, absoluteTolerance: float = 1e-6) -> bool:

--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
@@ -331,6 +331,12 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
         if not warnings:
             return
 
+        jbWarnings = [msg for msg in warnings if "JbIntegral" in msg]
+        jfWarnings = [msg for msg in warnings if "JfIntegral" in msg]
+        otherWarnings = [
+            msg for msg in warnings if "JbIntegral" not in msg and "JfIntegral" not in msg
+        ]
+
         allowedImaginaryOptions = {
             EImaginaryOption.PRINCIPAL_PART,
             EImaginaryOption.ABS_ARGUMENT,
@@ -340,15 +346,14 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
             self._logWarnings(warnings)
             return
 
-        # Check if the real part validates.
-        realPartChecks: list[bool] = []
-        if any("JbIntegral" in warningMessage for warningMessage in warnings):
-            realPartChecks.append(self._validateFirstColumn(self.integrals.Jb))
-        if any("JfIntegral" in warningMessage for warningMessage in warnings):
-            realPartChecks.append(self._validateFirstColumn(self.integrals.Jf))
+        warningsToLog = list(otherWarnings)
+        if jbWarnings and not self._validateFirstColumn(self.integrals.Jb):
+            warningsToLog.extend(jbWarnings)
+        if jfWarnings and not self._validateFirstColumn(self.integrals.Jf):
+            warningsToLog.extend(jfWarnings)
 
-        if not all(realPartChecks):
-            self._logWarnings(warnings)
+        if warningsToLog:
+            self._logWarnings(warningsToLog)
 
     def _readInterpolationTablesWithCapturedValidationWarnings(
         self, thisFileDirectory: str

--- a/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
+++ b/Models/SingletStandardModel_Z2/singletStandardModelZ2.py
@@ -32,7 +32,8 @@ import os
 import sys
 import pathlib
 import argparse
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Any
 import numpy as np
 
 # WallGo imports
@@ -52,6 +53,26 @@ from wallGoExampleBase import ExampleInputPoint  # pylint: disable=C0411, C0413,
 
 if TYPE_CHECKING:
     import WallGoCollision
+
+
+class _InterpolationWarningCatcher(logging.Handler):
+    """Capture interpolation table validation warnings for conditional handling."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        message = record.getMessage()
+        if "Could not validate interpolation table" in message:
+            self.messages.append(message)
+
+
+class _SuppressInterpolationValidationWarningFilter(logging.Filter):
+    """Temporarily suppress targeted validation warnings from normal handlers."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "Could not validate interpolation table" not in record.getMessage()
 
 
 class SingletSMZ2(GenericModel):
@@ -290,12 +311,39 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
         # Load custom interpolation tables for Jb/Jf. These should be
         # the same as what CosmoTransitions version 2.0.2 provides by default.
         thisFileDirectory = os.path.dirname(os.path.abspath(__file__))
-        self.integrals.Jb.readInterpolationTable(
-            os.path.join(thisFileDirectory, "interpolationTable_Jb_testModel.txt"),
-        )
-        self.integrals.Jf.readInterpolationTable(
-            os.path.join(thisFileDirectory, "interpolationTable_Jf_testModel.txt"),
-        )
+        
+        # By default, the WallGo prints a warning if there is a mismatch between
+        # the interpolation table and the direct evaluation of the integral.
+        # Since our benchmark tables have no entry for the imaginary part, we
+        # will get such a warning. For imaginaryOptions PRINCIPAL_PART and ABS_ARGUMENT,
+        # only the real part is relevant, so we can suppress the warning.
+        warningCatcher = _InterpolationWarningCatcher()
+        suppressFilter = _SuppressInterpolationValidationWarningFilter()
+        rootLogger = logging.getLogger()
+
+        # Suppress immediate printing of the specific validation warning while still
+        # capturing it in warningCatcher for conditional handling below.
+        filteredHandlers: list[logging.Handler] = []
+        for handler in rootLogger.handlers:
+            handler.addFilter(suppressFilter)
+            filteredHandlers.append(handler)
+
+        rootLogger.addHandler(warningCatcher)
+        try:
+            self.integrals.Jb.readInterpolationTable(
+                os.path.join(thisFileDirectory, "interpolationTable_Jb_testModel.txt"),
+            )
+            self.integrals.Jf.readInterpolationTable(
+                os.path.join(thisFileDirectory, "interpolationTable_Jf_testModel.txt"),
+            )
+        finally:
+            rootLogger.removeHandler(warningCatcher)
+            for handler in filteredHandlers:
+                handler.removeFilter(suppressFilter)
+
+        # Check if any warnings were captured. If so, check the real part
+        # separately, and only print a warning if it does not validate.
+        self._handleInterpolationValidationWarnings(warningCatcher.messages)
 
         self.integrals.Jb.disableAdaptiveInterpolation()
         self.integrals.Jf.disableAdaptiveInterpolation()
@@ -317,6 +365,48 @@ class EffectivePotentialxSMZ2(EffectivePotentialNoResum):
             extrapolationTypeLower=EExtrapolationType.CONSTANT,
             extrapolationTypeUpper=EExtrapolationType.CONSTANT,
         )
+
+    def _handleInterpolationValidationWarnings(self, warnings: list[str]) -> None:
+        """Handle interpolation validation warnings."""
+        if not warnings:
+            return
+
+        allowedImaginaryOptions = {
+            EImaginaryOption.PRINCIPAL_PART,
+            EImaginaryOption.ABS_ARGUMENT,
+        }
+
+        if self.imaginaryOption not in allowedImaginaryOptions:
+            for warningMessage in warnings:
+                logging.warning(warningMessage)
+            return
+
+        # For principal-part and abs-argument workflows, only the real part is needed.
+        realPartValid = True
+        if any("JbIntegral" in warningMessage for warningMessage in warnings):
+            realPartValid = realPartValid and self._validateFirstColumn(self.integrals.Jb)
+        if any("JfIntegral" in warningMessage for warningMessage in warnings):
+            realPartValid = realPartValid and self._validateFirstColumn(self.integrals.Jf)
+
+        if not realPartValid:
+            for warningMessage in warnings:
+                logging.warning(warningMessage)
+
+    @staticmethod
+    def _validateFirstColumn(integral: Any, absoluteTolerance: float = 1e-6) -> bool:
+        """Validate interpolation using only the real-part (first) output column."""
+        xMin = integral.interpolationRangeMin()
+        xMax = integral.interpolationRangeMax()
+        testPoints = (xMin, xMax, (xMax - xMin) / 2.55)
+
+        for xValue in testPoints:
+            interpolated = np.asarray(integral.evaluateInterpolation(xValue))[0]
+            direct = np.asarray(
+                integral.evaluate(xValue, bUseInterpolatedValues=False)
+            )[0]
+            if np.abs(interpolated - direct) > absoluteTolerance:
+                return False
+        return True
 
     def evaluate(
         self, fields: Fields, temperature: float


### PR DESCRIPTION
When running Models/SingletStandardModel_Z2/singletStandardModelZ2.py on main, WallGo prints 

JbIntegral: Could not validate interpolation table! Value discrepancy was [-9.76996262e-15 -3.27643655e+00]

and similar for Jf.
The reason is that singletStandardModelZ2.py uses non-standard tables for Jf and Jb, and these do not contain the imaginary part of the J functions. Consequently, the validation against the built-in J-functions, which checks both the real and imaginary part, fails.

The warning is triggered by _validateInterpolationTable in InterpolatableFunction, which is called by readInterpolationTable.

I have modified the part of the model file where readInterpolationTable is called - such that the warning does not get printed for EImaginaryOption.PRINCIPAL_PART and EImaginaryOption.ABS_ARGUMENT (but only if the real part *does* validate).

The current implementation seems to work (you can test by changing e.g. manually the value in the Jb table), but I find it a bit long and cumbersome.
I would have preferred to implement something in the source code, but stumbled on the problem that the function _validateInterpolationTable is not specific to J-functions, and moreover has no knowledge about the chosen EImaginaryOption.
Since readInterpolationTable is only called in the model file, this seemed the most natural place to deal with the warnings. 

An alternative solution is to just provide the imaginary part in the table. Even though it isn't strictly necessary, it might be preferable over adding another ~50 lines of code. I have therefore marked this as a draft pull request.