### PR TITLE
fix in Boltzmann pointed out in Wikicho issue 377

### DIFF
--- a/src/WallGo/boltzmann.py
+++ b/src/WallGo/boltzmann.py
@@ -713,7 +713,7 @@ class BoltzmannSolver:
             dTemperaturedChi = (derivMatrixChi @ temperatureFull)[
                 None, 1:-1, None, None
             ]
-            dvdChi = (derivMatrixChi @ temperatureFull)[None, 1:-1, None, None]
+            dvdChi = (derivMatrixChi @ vFull)[None, 1:-1, None, None] #Thanks to Wonsub Cho for pointing out a bug.
             # the following is equivalent to:
             # dMsqdChiEinsum = np.einsum(
             #   "ij,aj->ai", derivMatrixChi.toarray(), msqFull


### PR DESCRIPTION
Fixes issue https://github.com/Wall-Go/WallGo/issues/377

The derivative dvdChi was computed using the temperature profile instead of the velocity profile in the finite difference method. The fix should therefore affect mainly the error estimate, not the value of the wall velocity itself.

For the SingletZ2 example model, the result is unmodified. 