### PR TITLE
added return values in EOM for detonation solution

### DIFF
--- a/src/WallGo/equationOfMotion.py
+++ b/src/WallGo/equationOfMotion.py
@@ -347,8 +347,8 @@ class EOM:
                         vw2,
                         vw3,
                         wallParams2,
-                        wallPressureResults1[0:5],
-                        wallPressureResults2[0:5],
+                        wallPressureResults1,
+                        wallPressureResults2,
                     )
                 )
                 if onlySmallest:
@@ -404,13 +404,25 @@ class EOM:
         wallParamsGuess: WallParams,
         wallPressureResultsMin: (
             tuple[
-                float, WallParams, BoltzmannResults, BoltzmannBackground, HydroResults
+                float,
+                WallParams,
+                BoltzmannResults,
+                BoltzmannBackground,
+                HydroResults,
+                float,
+                float,
             ]
             | None
         ) = None,
         wallPressureResultsMax: (
             tuple[
-                float, WallParams, BoltzmannResults, BoltzmannBackground, HydroResults
+                float,
+                WallParams,
+                BoltzmannResults,
+                BoltzmannBackground,
+                HydroResults,
+                float,
+                float,
             ]
             | None
         ) = None,


### PR DESCRIPTION
Small addition to https://github.com/Wall-Go/WallGo/pull/371

When searching for a detonation in the xSM model file, I still got an error

" ...equationOfMotion.py", line 470, in solveWall
    (
ValueError: not enough values to unpack (expected 7, got 5)"

This gets corrected by this commit.