### PR TITLE
Track when plasmaProfilePoint does not solve and small fix in base example

### DIFF
--- a/Models/Yukawa/yukawa.py
+++ b/Models/Yukawa/yukawa.py
@@ -205,17 +205,23 @@ def main() -> None:
 
     results = manager.solveWall(solverSettings)
 
-    print(
-        f"Wall velocity without out-of-equilibrium contributions {results.wallVelocity:.6f}"
-    )
+    if results.success is True and results.wallVelocity is not None:
+        print(
+            f"Wall velocity without out-of-equilibrium contributions {results.wallVelocity:.6f}"
+        )
+    else:
+        print(results.message)
 
     solverSettings.bIncludeOffEquilibrium = True
 
     results = manager.solveWall(solverSettings)
 
-    print(
-        f"Wall velocity with out-of-equilibrium contributions {results.wallVelocity:.6f}"
-    )
+    if results.success is True and results.wallVelocity is not None:
+        print(
+            f"Wall velocity with out-of-equilibrium contributions {results.wallVelocity:.6f}"
+        )
+    else:
+        print(results.message)
 
 
 ## Don't run the main function if imported to another file

--- a/Models/wallGoExampleBase.py
+++ b/Models/wallGoExampleBase.py
@@ -204,7 +204,7 @@ class WallGoExampleBase(ABC):
         )
 
         print(header)
-        if results.wallVelocity is not None:
+        if results.wallVelocity is not None and results.success is True:
             print(f"wallVelocity:      {results.wallVelocity:.6f}")
             print(f"wallVelocityError: {results.wallVelocityError:.6f}")
             print(f"wallWidths:        {results.wallWidths}")

--- a/src/WallGo/equationOfMotion.py
+++ b/src/WallGo/equationOfMotion.py
@@ -132,6 +132,8 @@ class EOM:
         self.pressRelErrTol = pressRelErrTol
         self.pressAbsErrTol = 0.0
 
+        ## Flag to detect if a velocity and temperature profile point was found successfully
+        self.successPlasmaProfilePoint = True
         ## Flag to detect if the temperature profile was found successfully
         self.successTemperatureProfile = True
         ## Flag to detect if we were able to find the pressure
@@ -1806,6 +1808,11 @@ class EOM:
             if T > 0:
                 temperatureProfile[index] = T
                 velocityProfile[index] = vPlasma
+
+                # If findPlasmaProfilePoint returned the minimum of the LHS, 
+                # instead of finding the root, the temperature profile hase also failed.
+                if not self.successPlasmaProfilePoint:
+                    self.successTemperatureProfile = False
             else:
                 ## If no solution was found, use the last point
                 temperatureProfile[index] = temperatureProfile[index - 1]
@@ -1882,6 +1889,7 @@ class EOM:
         if self.temperatureProfileEqLHS(fields, dPhidz, minRes.x, s1, s2) >= 0:
             T = minRes.x
             vPlasma = self.plasmaVelocity(fields, T, s1)
+            self.successPlasmaProfilePoint = False
             return T, vPlasma
 
         # Bracketing the root
@@ -1895,6 +1903,7 @@ class EOM:
         i = 0  # pylint: disable=invalid-name
         while self.temperatureProfileEqLHS(fields, dPhidz, testTemp, s1, s2) < 0:
             if i > 100:
+                self.successPlasmaProfilePoint = False
                 ## No solution was found. We return 0.
                 return 0, 0
             tempAtMinimum *= TMultiplier
@@ -1911,6 +1920,7 @@ class EOM:
 
         T = res
         vPlasma = self.plasmaVelocity(fields, T, s1)
+        self.successPlasmaProfilePoint = True
         return T, vPlasma
 
     def plasmaVelocity(

--- a/src/WallGo/equationOfMotion.py
+++ b/src/WallGo/equationOfMotion.py
@@ -202,6 +202,12 @@ class EOM:
             self.includeOffEq):
             # If there is a LTE solution but no out-of-equilibrium one, retry with vmax
             # set to the LTE velocity.
+            logging.warning(
+                f"\n Warning: No deflagration/hybrid solution was found with vmax={vmax:.6f}.\n"
+                f" Error message: {results.message}\n"
+                f" A hydro LTE solution exists. We therefore try again with vmax set to the\n"
+                f" LTE velocity {self.wallVelocityLTE:.6f}.\n"
+            )
             results = self.solveWall(vmin, self.wallVelocityLTE, wallParams)
             
         return results


### PR DESCRIPTION
Fixes issues https://github.com/Wall-Go/WallGo/issues/234 and https://github.com/Wall-Go/WallGo/issues/382

In the function plasmaProfilePoint, when no solution can be found, the minimum is returned, rather than the root. This is OK if it happens at some point in the many iterations, but it should not happen on the final solution.
I now set successTemperatureProfile to False if any of the points on the final solution does not correspond to a proper solution.

 It turned out that even when equationOfMotion set the success state to False, our example base would still return the value (if it was non-zero). I now added an additional check, such that it will *not* return a solution when the success state is set to false.

If you want to test this, you can add +100.**4 on line 1995 of equationOfMotion (in temperatureProfileEqLHS). This should give an error, because the temperatureProfile equation can no longer be solved for all points.